### PR TITLE
Gjør navigasjonspanelet fullhøyt

### DIFF
--- a/nordlys/ui/pyside_app.py
+++ b/nordlys/ui/pyside_app.py
@@ -443,8 +443,9 @@ class NavigationPanel(QFrame):
         self.tree.setExpandsOnDoubleClick(False)
         self.tree.setIndentation(12)
         self.tree.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.tree.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.tree.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         layout.addWidget(self.tree, 1)
-        layout.addStretch(1)
 
     def add_root(self, title: str, key: str | None = None) -> NavigationItem:
         item = QTreeWidgetItem([title])


### PR DESCRIPTION
## Sammendrag
- legger til utvidende størrelsespolitikk for navigasjonspanelet slik at det dekker hele vinduets høyde
- slår av rullefelt i navigasjonstreet for å unngå unødvendig scrolling

## Testing
- pytest *(feilet på grunn av manglende tredjepartsbiblioteker i miljøet)*

------
https://chatgpt.com/codex/tasks/task_e_6905fc64f1ec8328865e32a30f7b7f33