### PR TITLE
Fiks nøkkeloppslag for lister i Brreg-modulen

### DIFF
--- a/nordlys/brreg.py
+++ b/nordlys/brreg.py
@@ -34,14 +34,17 @@ def find_numbers(data: object, path: str = '') -> List[Tuple[str, float]]:
 
 
 def _last_key(segment_path: str) -> str:
+    """Returnerer siste nøkkelkomponent i en punktseparert sti."""
+
     parts = segment_path.split('.')
-    while parts:
-        last = parts[-1]
-        if '[' in last:
-            last = last.split(']')[-1]
-        if last and not last.endswith(']'):
-            return last
-        parts = parts[:-1]
+    for part in reversed(parts):
+        if not part:
+            continue
+        if '[' in part:
+            part = part.split('[', 1)[0]
+        part = part.strip()
+        if part:
+            return part
     return ''
 
 

--- a/tests/test_brreg.py
+++ b/tests/test_brreg.py
@@ -15,10 +15,17 @@ def test_find_first_by_exact_endkey():
                 'sumEgenkapital': 400,
                 'sumGjeld': 600,
             },
+            'poster': [
+                {'sumGjeld': 50},
+                {'sumGjeld': 70},
+            ],
         },
     }
     hit = find_first_by_exact_endkey(data, ['sumDriftsinntekter'])
     assert hit == ('resultatregnskap.sumDriftsinntekter', 123)
+
+    list_hit = find_first_by_exact_endkey(data, ['sumGjeld'])
+    assert list_hit == ('balanse.egenkapitalOgGjeld.sumGjeld', 600)
 
 
 def test_map_brreg_metrics():


### PR DESCRIPTION
## Sammendrag
- rette `_last_key` slik at stier med listeindekser tolkes riktig
- utvide deksende test for `find_first_by_exact_endkey` med eksempel fra lister

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_6906093a9d1c83289630587265f0595a