### PR TITLE
Legg til saldobalanse-side og gjør navigasjonen statisk

### DIFF
--- a/nordlys/ui/pyside_app.py
+++ b/nordlys/ui/pyside_app.py
@@ -543,6 +543,7 @@ class NavigationPanel(QFrame):
         self.tree.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.tree.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.tree.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.tree.setItemsExpandable(False)
         self.tree.itemCollapsed.connect(self._on_item_collapsed)
         layout.addWidget(self.tree, 1)
 
@@ -745,6 +746,7 @@ class NordlysWindow(QMainWindow):
 
         nav.tree.currentItemChanged.connect(self._on_navigation_changed)
         nav.tree.setCurrentItem(dashboard_item.item)
+        nav.tree.expandAll()
 
         for key, items in REVISION_TASKS.items():
             page = self.revision_pages.get(key)


### PR DESCRIPTION
## Oppsummering
- la planlegging få en egen saldobalanse-side med tabell fra SAF-T
- låste planlegging- og revisjon-gruppene i navigasjonen slik at de ikke kan kollapses og fjernet indikatorene
- fjernet fokusrammen fra knapper for et renere visuelt uttrykk

## Tester
- pytest *(feilet: mangler requests og pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6906128cc17483288cae69be6f5adf2e