### PR TITLE
Forbedre lesbarheten i dashboardstatus

### DIFF
--- a/nordlys/ui/__init__.py
+++ b/nordlys/ui/__init__.py
@@ -1,9 +1,16 @@
 """GUI-moduler for Nordlys."""
 
-from .pyside_app import NordlysWindow, create_app, run
+from importlib import import_module
+from typing import TYPE_CHECKING
 
-__all__ = [
-    "NordlysWindow",
-    "create_app",
-    "run",
-]
+__all__ = ["NordlysWindow", "create_app", "run"]
+
+if TYPE_CHECKING:  # pragma: no cover - kun for typehjelp
+    from .pyside_app import NordlysWindow, create_app, run
+
+
+def __getattr__(name: str):  # pragma: no cover - enkel delegasjon
+    if name in __all__:
+        module = import_module(".pyside_app", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/nordlys/ui/formatting.py
+++ b/nordlys/ui/formatting.py
@@ -1,0 +1,68 @@
+"""Formateringshjelpere for Nordlys sitt brukergrensesnitt."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+__all__ = ["format_orgnr", "format_period", "format_account_count"]
+
+
+def format_orgnr(value: Optional[str]) -> str:
+    if not value:
+        return "–"
+    digits = "".join(ch for ch in value if ch.isdigit())
+    if len(digits) == 9:
+        return f"{digits[:3]} {digits[3:6]} {digits[6:]}"
+    stripped = value.strip()
+    return stripped or "–"
+
+
+def _format_period_value(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y%m%d"):
+        try:
+            return datetime.strptime(text, fmt).strftime("%d.%m.%Y")
+        except ValueError:
+            continue
+    if text.isdigit():
+        if len(text) <= 2:
+            return text.zfill(2)
+        if len(text) == 4:
+            return text
+    return text
+
+
+def format_period(fiscal_year: Optional[str], start: Optional[str], end: Optional[str]) -> str:
+    year_txt = (fiscal_year or "").strip()
+    start_txt = _format_period_value(start)
+    end_txt = _format_period_value(end)
+
+    range_txt: Optional[str]
+    if start_txt and end_txt:
+        if start_txt == end_txt:
+            range_txt = start_txt
+        else:
+            range_txt = f"{start_txt} – {end_txt}"
+    else:
+        range_txt = start_txt or end_txt
+
+    parts: List[str] = []
+    if year_txt:
+        parts.append(year_txt)
+    if range_txt:
+        label = "Periode" if " – " not in range_txt and (start_txt == end_txt or end_txt is None) else "Perioder"
+        parts.append(f"{label} {range_txt}")
+
+    if not parts:
+        return "–"
+    if len(parts) == 1:
+        return parts[0]
+    return " · ".join(parts)
+
+
+def format_account_count(value: int) -> str:
+    return f"{value:,}".replace(",", " ").replace(".", " ")

--- a/nordlys/utils.py
+++ b/nordlys/utils.py
@@ -35,20 +35,28 @@ def findall_any_namespace(inv: ET.Element, localname: str) -> List[ET.Element]:
     return matches
 
 
+def _format_amount(value: float) -> str:
+    formatted = f"{abs(value):,.0f}".replace(",", " ").replace(".", " ")
+    sign = "-" if value < 0 else ""
+    return f"{sign}{formatted} kr"
+
+
 def format_currency(value: Optional[float]) -> str:
-    """Formatterer beløp til heltall med tusenskilletegn."""
+    """Formatterer beløp som hele kroner med norske skilletegn."""
     try:
-        return f"{round(float(value)):,.0f}"
+        amount = round(float(value))
     except Exception:
         return "—"
+    return _format_amount(float(amount))
 
 
 def format_difference(a: Optional[float], b: Optional[float]) -> str:
-    """Formatterer differansen mellom to beløp."""
+    """Formatterer differansen mellom to beløp som hele kroner."""
     try:
-        return f"{round(float(a) - float(b)):,.0f}"
+        amount = round(float(a) - float(b))
     except Exception:
         return "—"
+    return _format_amount(float(amount))
 
 
 __all__ = [

--- a/tests/test_saft.py
+++ b/tests/test_saft.py
@@ -15,6 +15,7 @@ from nordlys.saft import (
     validate_saft_against_xsd,
 )
 from nordlys.utils import format_currency, format_difference
+from nordlys.ui.formatting import format_orgnr, format_period
 
 
 def build_sample_root() -> ET.Element:
@@ -123,8 +124,15 @@ def test_extract_sales_and_ar():
 
 
 def test_format_helpers():
-    assert format_currency(1234.5) == '1,234'
-    assert format_difference(2000, 1500) == '500'
+    assert format_currency(1234.5) == '1 234 kr'
+    assert format_difference(2000, 1500) == '500 kr'
+
+
+def test_dashboard_format_helpers():
+    assert format_orgnr('999999999') == '999 999 999'
+    assert format_orgnr('') == '–'
+    assert format_period('2023', '01', '12') == '2023 · Perioder 01 – 12'
+    assert format_period(None, '2023-01-01', '2023-12-31') == 'Perioder 01.01.2023 – 31.12.2023'
 
 
 def test_validate_saft_against_xsd_unknown_version(tmp_path):


### PR DESCRIPTION
## Sammendrag
- La til dedikerte formateringshjelpere for organisasjonsnummer, perioder og kontotelling
- Oppdaterte dashboardet og toppteksten til å bruke norske formateringer for statusinformasjon
- Tilpasset valuta- og differanseformatering til norske tusenskilletegn og kroner
- Gjorde UI-pakken lat til å importere PySide for å unngå unødvendige avhengigheter

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690619f28d48832891bada9fbcd98406