### PR TITLE
Fjern navneforklaring fra README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # Nordlys
 
-Nordlys er et Python-basert analyseverktøy som hjelper revisorer og controllere med å få oversikt over SAF-T-filer. Navnevalget Nordlys gjenspeiler målet om å gi klar sikt i komplekse regnskapsdata gjennom et moderne skrivebordsgrensesnitt bygget med PySide6. Løsningen kombinerer informasjon fra regnskapsregisteret med data som leses fra SAF-T-filer og presenterer resultatet i et visuelt og interaktivt grensesnitt.
-
-## Hvorfor Nordlys?
-
-- ✨ Konsekvent profilering gjør det enklere å introdusere løsningen internt og eksternt.
-- 🧭 Klart navn i vinduer, dokumentasjon og installasjonslister reduserer forvirring for sluttbrukere.
-- 🔁 Ensartet navnebruk forenkler vedlikehold, testing og videreutvikling.
+Nordlys er et Python-basert analyseverktøy som hjelper revisorer og controllere med å få oversikt over SAF-T-filer. Målet er å gi klar sikt i komplekse regnskapsdata gjennom et moderne skrivebordsgrensesnitt bygget med PySide6. Løsningen kombinerer informasjon fra regnskapsregisteret med data som leses fra SAF-T-filer og presenterer resultatet i et visuelt og interaktivt grensesnitt.
 
 ## Hovedfunksjoner
 


### PR DESCRIPTION
## Sammendrag
- fjernet omtale av navnevalget og hele seksjonen «Hvorfor Nordlys?» fra dokumentasjonen


------
https://chatgpt.com/codex/tasks/task_e_690627dbc5648328bb492f26ad6ba02a