### PR TITLE
Lat innlasting av tunge avhengigheter

### DIFF
--- a/nordlys/_lazy_imports.py
+++ b/nordlys/_lazy_imports.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any, Optional
+
+
+class LazyModule:
+    """En enkel wrapper som importerer modul ved første bruk."""
+
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: Optional[ModuleType] = None
+
+    def _load(self) -> ModuleType:
+        if self._module is None:
+            self._module = import_module(self._module_name)
+        return self._module
+
+    def module(self) -> ModuleType:
+        """Returnerer den underliggende modulen, og importerer den ved behov."""
+
+        return self._load()
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._load(), item)
+
+    def __dir__(self) -> list[str]:  # pragma: no cover - brukt for inspeksjon
+        module = self._load()
+        combined = set(dir(type(self))) | set(dir(module))
+        return sorted(combined)
+
+
+__all__ = ["LazyModule"]

--- a/nordlys/ui/pyside_app.py
+++ b/nordlys/ui/pyside_app.py
@@ -7,9 +7,8 @@ import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, cast
 
-import pandas as pd
 from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot
 from PySide6.QtGui import QBrush, QColor, QFont
 from PySide6.QtWidgets import (
@@ -42,6 +41,7 @@ from PySide6.QtWidgets import (
     QTableWidgetItem,
 )
 
+from .._lazy_imports import LazyModule
 from ..brreg import fetch_brreg, find_first_by_exact_endkey, map_brreg_metrics
 from ..constants import APP_TITLE
 from ..saft import (
@@ -57,6 +57,12 @@ from ..saft import (
     validate_saft_against_xsd,
 )
 from ..utils import format_currency, format_difference
+
+
+if TYPE_CHECKING:
+    import pandas as pd
+else:  # pragma: no cover - modul lastes latskaplig
+    pd = cast(Any, LazyModule("pandas"))
 
 
 REVISION_TASKS: Dict[str, List[str]] = {


### PR DESCRIPTION
## Oppsummering
- la til en felles `LazyModule`-hjelper som importerer moduler først når de brukes
- gjorde pandas-avhengigheten i GUI- og SAF-T-modulene lat slik at appen starter raskere
- flyttet import av `xmlschema` til selve valideringskallet slik at valgfri avhengighet ikke blokkerer oppstart

## Testing
- pytest *(feilet fordi miljøet mangler requests/pandas)*

------
https://chatgpt.com/codex/tasks/task_e_690658608ee08328976f254de28b6ee9