### PR TITLE
Legg til test for disallow_contains i brreg

### DIFF
--- a/tests/test_brreg.py
+++ b/tests/test_brreg.py
@@ -28,6 +28,27 @@ def test_find_first_by_exact_endkey():
     assert list_hit == ('balanse.egenkapitalOgGjeld.sumGjeld', 600)
 
 
+def test_find_first_by_exact_endkey_disallow_contains():
+    data = {
+        'balanse': {
+            'egenkapitalOgGjeld': {
+                'sumEgenkapital': 400,
+            },
+            'egenkapital': {
+                'sumEgenkapital': 380,
+            },
+        }
+    }
+
+    hit = find_first_by_exact_endkey(
+        data,
+        ['sumEgenkapital'],
+        disallow_contains=['egenkapitaloggjeld'],
+    )
+
+    assert hit == ('balanse.egenkapital.sumEgenkapital', 380.0)
+
+
 def test_map_brreg_metrics():
     data = {
         'resultatregnskap': {


### PR DESCRIPTION
## Oppsummering
- legger til ny enhetstest for find_first_by_exact_endkey med disallow_contains
- sikrer at nøkler som inneholder forbudte delstrenger hoppes over til fordel for gyldig resultat

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69066ff0f7e8832886ab2f50d5dd2d83