### PR TITLE
Oppdater visning av leverandørinnkjøp

### DIFF
--- a/nordlys/ui/pyside_app.py
+++ b/nordlys/ui/pyside_app.py
@@ -870,10 +870,10 @@ class PurchasesApPage(QWidget):
         )
         header = self.top_table.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.ResizeToContents)
+        self.top_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.top_card.add_widget(self.top_table)
-        layout.addWidget(self.top_card)
-
-        layout.addStretch(1)
+        self.top_card.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        layout.addWidget(self.top_card, 1)
 
         self.set_controls_enabled(False)
 


### PR DESCRIPTION
## Oppsummering
- endret kortet for leverandøranalyse til "Innkjøp per leverandør" og fjernet den tomme informasjonsbolken
- sørget for at tabellkolonner for leverandørdata tilpasses innholdet og oppdaterte statusmeldingen

## Testing
- `pytest` (feiler på kjent test relatert til eksport til Excel uten openpyxl)


------
https://chatgpt.com/codex/tasks/task_e_69067480eb5883289b64d36b6cea6b29