### PR TITLE
Legg til minimal XLSX-fallback når xlsxwriter mangler

### DIFF
--- a/nordlys/saft_customers.py
+++ b/nordlys/saft_customers.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 from collections import defaultdict
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+import numbers
 from pathlib import Path
 from typing import Dict, Iterable, Optional, Tuple
 import xml.etree.ElementTree as ET
+from xml.sax.saxutils import escape
+import zipfile
 
 import pandas as pd
 
@@ -577,12 +580,132 @@ def save_outputs(
         try:
             import xlsxwriter  # type: ignore  # noqa: F401
         except ModuleNotFoundError:
-            csv_fallback_path = xlsx_path.with_suffix(".csv")
-            export_df.to_csv(csv_fallback_path, index=False, encoding="utf-8-sig")
-            return csv_path, csv_fallback_path
+            _write_basic_xlsx(export_df, xlsx_path)
+            return csv_path, xlsx_path
         with pd.ExcelWriter(xlsx_path, engine="xlsxwriter") as writer:
             export_df.to_excel(writer, index=False)
     return csv_path, xlsx_path
+
+
+def _excel_column_letter(index: int) -> str:
+    """Konverterer 1-basert kolonneindeks til Excel-kolonnebokstaver."""
+
+    result = ""
+    current = index
+    while current > 0:
+        current, remainder = divmod(current - 1, 26)
+        result = chr(65 + remainder) + result
+    return result or "A"
+
+
+def _write_basic_xlsx(df: pd.DataFrame, path: Path) -> None:
+    """Skriver en minimalistisk XLSX-fil uten eksterne avhengigheter."""
+
+    path = Path(path)
+
+    def build_cell(row_index: int, col_index: int, value: object) -> Optional[str]:
+        if pd.isna(value):
+            return None
+        cell_ref = f"{_excel_column_letter(col_index)}{row_index}"
+        if isinstance(value, bool):
+            return f'<c r="{cell_ref}" t="b"><v>{int(value)}</v></c>'
+        if isinstance(value, Decimal):
+            return f'<c r="{cell_ref}"><v>{value}</v></c>'
+        if isinstance(value, numbers.Integral):
+            return f'<c r="{cell_ref}"><v>{int(value)}</v></c>'
+        if isinstance(value, numbers.Real):
+            return f'<c r="{cell_ref}"><v>{value}</v></c>'
+        text = escape(str(value))
+        return f'<c r="{cell_ref}" t="inlineStr"><is><t>{text}</t></is></c>'
+
+    def build_header(row_index: int) -> str:
+        cells = [
+            f'<c r="{_excel_column_letter(col)}{row_index}" t="inlineStr"><is><t>{escape(str(header))}</t></is></c>'
+            for col, header in enumerate(df.columns, start=1)
+        ]
+        return f'<row r="{row_index}">' + "".join(cells) + "</row>"
+
+    def build_body(start_row: int) -> str:
+        rows = []
+        row_number = start_row
+        for record in df.itertuples(index=False, name=None):
+            cells = []
+            for col_index, value in enumerate(record, start=1):
+                cell = build_cell(row_number, col_index, value)
+                if cell:
+                    cells.append(cell)
+            rows.append(f'<row r="{row_number}">' + "".join(cells) + "</row>")
+            row_number += 1
+        return "".join(rows)
+
+    header_xml = build_header(1)
+    body_xml = build_body(2)
+
+    sheet_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" "
+        "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+        "<sheetData>"
+        f"{header_xml}{body_xml}"
+        "</sheetData>"
+        "</worksheet>"
+    )
+
+    content_types_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">"
+        "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>"
+        "<Default Extension=\"xml\" ContentType=\"application/xml\"/>"
+        "<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>"
+        "<Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>"
+        "<Override PartName=\"/xl/styles.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\"/>"
+        "</Types>"
+    )
+
+    rels_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>"
+        "</Relationships>"
+    )
+
+    workbook_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" "
+        "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+        "<sheets>"
+        "<sheet name=\"Sheet1\" sheetId=\"1\" r:id=\"rId1\"/>"
+        "</sheets>"
+        "</workbook>"
+    )
+
+    workbook_rels_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>"
+        "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>"
+        "</Relationships>"
+    )
+
+    styles_xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">"
+        "<fonts count=\"1\"><font/></fonts>"
+        "<fills count=\"1\"><fill><patternFill patternType=\"none\"/></fill></fills>"
+        "<borders count=\"1\"><border/></borders>"
+        "<cellStyleXfs count=\"1\"><xf/></cellStyleXfs>"
+        "<cellXfs count=\"1\"><xf xfId=\"0\"/></cellXfs>"
+        "<cellStyles count=\"1\"><cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\"/></cellStyles>"
+        "</styleSheet>"
+    )
+
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("[Content_Types].xml", content_types_xml)
+        archive.writestr("_rels/.rels", rels_xml)
+        archive.writestr("xl/workbook.xml", workbook_xml)
+        archive.writestr("xl/_rels/workbook.xml.rels", workbook_rels_xml)
+        archive.writestr("xl/styles.xml", styles_xml)
+        archive.writestr("xl/worksheets/sheet1.xml", sheet_xml)
 
 
 __all__ = [


### PR DESCRIPTION
## Oppsummering
- legger til en intern skrivefunksjon som lager gyldige XLSX-filer når både openpyxl og xlsxwriter mangler
- sikrer at save_outputs alltid returnerer en .xlsx-fil selv uten eksterne excel-avhengigheter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_690676f16a788328a739b90b4b207ff2