### PR TITLE
Forbedre håndtering av manglende filer i SAF-T validering

### DIFF
--- a/nordlys/saft.py
+++ b/nordlys/saft.py
@@ -125,7 +125,7 @@ def _schema_info_for_family(family: Optional[str]) -> Optional[Tuple[Path, str]]
 def _extract_version_from_file(xml_path: Path) -> Optional[str]:
     try:
         root = ET.parse(xml_path).getroot()
-    except ET.ParseError:
+    except (ET.ParseError, OSError):
         return None
     header = parse_saft_header(root)
     return header.file_version if header else None

--- a/tests/test_saft.py
+++ b/tests/test_saft.py
@@ -172,6 +172,14 @@ def test_parse_saft_detects_namespace(tmp_path):
     assert ns['n1'] == 'urn:StandardAuditFile-Taxation-Financial:NO'
 
 
+def test_validate_saft_handles_missing_file(tmp_path):
+    missing_path = tmp_path / 'finnes_ikke.xml'
+    result = validate_saft_against_xsd(missing_path)
+
+    assert result.is_valid in (None, False)
+    assert result.details is not None and result.details.strip() != ''
+
+
 def test_get_amount_handles_nested_amount():
     line_xml = """
     <Line xmlns="urn:StandardAuditFile-Taxation-Financial:NO">


### PR DESCRIPTION
## Sammendrag
- sørg for at `_extract_version_from_file` returnerer `None` når SAF-T-filen ikke kan leses
- legg til en enhetstest som bekrefter at validering mot XSD håndterer manglende filer uten unntak

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_69071858d3688328b3e2d2af145f821c