### PR TITLE
Legg til regnskapsanalyse med balanse- og resultatoversikt

### DIFF
--- a/nordlys/regnskap.py
+++ b/nordlys/regnskap.py
@@ -1,0 +1,301 @@
+"""Beregninger for regnskapsanalysesiden."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class AnalysisRow:
+    """Representerer én rad i en aggregert visning."""
+
+    label: str
+    current: Optional[float]
+    previous: Optional[float]
+    change: Optional[float]
+    is_header: bool = False
+
+
+def prepare_regnskap_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Normaliserer saldobalansen til kolonner brukt i analysen."""
+
+    work = df.copy()
+
+    for column in [
+        "Konto",
+        "Kontonavn",
+        "IB Debet",
+        "IB Kredit",
+        "UB Debet",
+        "UB Kredit",
+    ]:
+        if column not in work.columns:
+            work[column] = 0.0
+
+    konto_series = work["Konto"].fillna("").astype(str)
+    navn_series = work.get("Kontonavn", "").fillna("")
+
+    ib_netto = work.get("IB_netto")
+    if ib_netto is None:
+        ib_netto = work["IB Debet"].fillna(0.0) - work["IB Kredit"].fillna(0.0)
+    else:
+        ib_netto = ib_netto.fillna(0.0)
+
+    ub_netto = work.get("UB_netto")
+    if ub_netto is None:
+        ub_netto = work["UB Debet"].fillna(0.0) - work["UB Kredit"].fillna(0.0)
+    else:
+        ub_netto = ub_netto.fillna(0.0)
+
+    endring = ub_netto - ib_netto
+
+    prepared = pd.DataFrame(
+        {
+            "konto": konto_series,
+            "navn": navn_series,
+            "IB": ib_netto,
+            "endring": endring,
+            "UB": ub_netto,
+            "forrige": work.get("forrige", ib_netto).fillna(0.0),
+        }
+    )
+
+    return prepared
+
+
+def _sum_column(prepared: pd.DataFrame, column: str, prefixes: Iterable[str]) -> float:
+    konto_text = prepared["konto"].astype(str).str.strip()
+    values = prepared[column].astype(float)
+    mask = pd.Series(False, index=prepared.index)
+    for prefix in prefixes:
+        mask |= konto_text.str.startswith(prefix)
+    if not mask.any():
+        return 0.0
+    return float(values.loc[mask].sum())
+
+
+def _clean_value(value: float) -> float:
+    value = float(value)
+    return 0.0 if abs(value) < 1e-6 else value
+
+
+def _make_row(label: str, current: float, previous: float) -> AnalysisRow:
+    current_clean = _clean_value(current)
+    previous_clean = _clean_value(previous)
+    return AnalysisRow(
+        label=label,
+        current=current_clean,
+        previous=previous_clean,
+        change=_clean_value(current_clean - previous_clean),
+    )
+
+
+def _make_header(label: str) -> AnalysisRow:
+    return AnalysisRow(label=label, current=None, previous=None, change=None, is_header=True)
+
+
+def compute_balance_analysis(prepared: pd.DataFrame) -> List[AnalysisRow]:
+    """Beregner balanseaggregater basert på kontonummer-prefikser."""
+
+    work = prepared
+
+    def sum_ub(*prefixes: str) -> float:
+        return _sum_column(work, "UB", prefixes)
+
+    def sum_py(*prefixes: str) -> float:
+        return _sum_column(work, "forrige", prefixes)
+
+    assets_rows: List[AnalysisRow] = []
+
+    assets_rows.append(_make_header("Eiendeler"))
+
+    immaterielle = sum_ub("10")
+    immaterielle_py = sum_py("10")
+    assets_rows.append(_make_row("10 Immaterielle", immaterielle, immaterielle_py))
+
+    tomter = sum_ub("11")
+    tomter_py = sum_py("11")
+    assets_rows.append(_make_row("11 Tomter/bygninger", tomter, tomter_py))
+
+    maskiner = sum_ub("12")
+    maskiner_py = sum_py("12")
+    assets_rows.append(_make_row("12 Maskiner/inventar/transport", maskiner, maskiner_py))
+
+    finans_anlegg = sum_ub("13")
+    finans_anlegg_py = sum_py("13")
+    assets_rows.append(_make_row("13 Finansielle anleggsmidler", finans_anlegg, finans_anlegg_py))
+
+    varelager = sum_ub("14")
+    varelager_py = sum_py("14")
+    assets_rows.append(_make_row("14 Varelager", varelager, varelager_py))
+
+    kundefordr = sum_ub("1500") + sum_ub("1580")
+    kundefordr_py = sum_py("1500") + sum_py("1580")
+    assets_rows.append(_make_row("Kundefordringer (netto)", kundefordr, kundefordr_py))
+
+    korts_fordr_total = sum_ub("15")
+    korts_fordr_total_py = sum_py("15")
+    korts_fordr_ovrige = korts_fordr_total - kundefordr
+    korts_fordr_ovrige_py = korts_fordr_total_py - kundefordr_py
+    assets_rows.append(
+        _make_row("Kortsiktige fordringer (øvrige)", korts_fordr_ovrige, korts_fordr_ovrige_py)
+    )
+
+    mva = sum_ub("16")
+    mva_py = sum_py("16")
+    assets_rows.append(_make_row("16 MVA/tilskudd", mva, mva_py))
+
+    forskudd = sum_ub("17")
+    forskudd_py = sum_py("17")
+    assets_rows.append(
+        _make_row("17 Forskuddsbet. kostn./påløpt inntekt", forskudd, forskudd_py)
+    )
+
+    finans_kortsiktig = sum_ub("18")
+    finans_kortsiktig_py = sum_py("18")
+    assets_rows.append(
+        _make_row("18 Kortsiktige finansinvesteringer", finans_kortsiktig, finans_kortsiktig_py)
+    )
+
+    bank = sum_ub("19")
+    bank_py = sum_py("19")
+    assets_rows.append(_make_row("19 Bank/kasse", bank, bank_py))
+
+    sum_eiendeler = sum(
+        value.current if value.current is not None else 0.0
+        for value in assets_rows
+        if not value.is_header
+    )
+    sum_eiendeler_py = sum(
+        value.previous if value.previous is not None else 0.0
+        for value in assets_rows
+        if not value.is_header
+    )
+
+    ek_rows: List[AnalysisRow] = []
+    ek_rows.append(_make_header("Egenkapital og gjeld"))
+
+    egenkapital = -sum_ub("20")
+    egenkapital_py = -sum_py("20")
+    ek_rows.append(_make_row("Egenkapital (20)", egenkapital, egenkapital_py))
+
+    avsetninger = -sum_ub("21")
+    avsetninger_py = -sum_py("21")
+    ek_rows.append(_make_row("21 Avsetninger", avsetninger, avsetninger_py))
+
+    langsiktig = -sum_ub("22")
+    langsiktig_py = -sum_py("22")
+    ek_rows.append(_make_row("22 Langsiktig gjeld", langsiktig, langsiktig_py))
+
+    kortsiktig = -sum(sum_ub(prefix) for prefix in ["23", "24", "25", "26", "27", "28", "29"])
+    kortsiktig_py = -sum(sum_py(prefix) for prefix in ["23", "24", "25", "26", "27", "28", "29"])
+    ek_rows.append(_make_row("Kortsiktig gjeld (23–29)", kortsiktig, kortsiktig_py))
+
+    sum_ek_gjeld = egenkapital + avsetninger + langsiktig + kortsiktig
+    sum_ek_gjeld_py = egenkapital_py + avsetninger_py + langsiktig_py + kortsiktig_py
+
+    control_rows: List[AnalysisRow] = []
+    control_rows.append(_make_header("Kontroll"))
+    control_rows.append(_make_row("Sum eiendeler", sum_eiendeler, sum_eiendeler_py))
+    control_rows.append(_make_row("Sum EK og gjeld", sum_ek_gjeld, sum_ek_gjeld_py))
+    control_rows.append(
+        _make_row(
+            "Differanse",
+            sum_eiendeler - sum_ek_gjeld,
+            sum_eiendeler_py - sum_ek_gjeld_py,
+        )
+    )
+
+    return assets_rows + ek_rows + control_rows
+
+
+def compute_result_analysis(prepared: pd.DataFrame) -> List[AnalysisRow]:
+    """Beregner resultatposter basert på kontonummer-prefikser."""
+
+    work = prepared
+
+    def sum_ub(*prefixes: str) -> float:
+        return _sum_column(work, "UB", prefixes)
+
+    def sum_py(*prefixes: str) -> float:
+        return _sum_column(work, "forrige", prefixes)
+
+    rows: List[AnalysisRow] = []
+    rows.append(_make_header("Resultat"))
+
+    annen_inntekt = -(sum_ub("38") + sum_ub("39"))
+    annen_inntekt_py = -(sum_py("38") + sum_py("39"))
+    rows.append(_make_row("Annen inntekt", annen_inntekt, annen_inntekt_py))
+
+    sum_salg_total = -sum_ub("3")
+    sum_salg_total_py = -sum_py("3")
+    salg = sum_salg_total - annen_inntekt
+    salg_py = sum_salg_total_py - annen_inntekt_py
+    rows.append(_make_row("Salgsinntekter (3xxx ekskl. 38/39)", salg, salg_py))
+
+    rows.append(_make_row("Sum inntekter", sum_salg_total, sum_salg_total_py))
+
+    varekostnad = sum_ub("4")
+    varekostnad_py = sum_py("4")
+    rows.append(_make_row("Varekostnad", varekostnad, varekostnad_py))
+
+    lonn = sum_ub("5")
+    lonn_py = sum_py("5")
+    rows.append(_make_row("Lønn", lonn, lonn_py))
+
+    avskr = sum_ub("60")
+    avskr_py = sum_py("60")
+    rows.append(_make_row("Av-/nedskrivning", avskr, avskr_py))
+
+    andre6_total = sum_ub("6")
+    andre6_total_py = sum_py("6")
+    andre_drift = andre6_total - avskr
+    andre_drift_py = andre6_total_py - avskr_py
+    rows.append(_make_row("Andre driftskostnader", andre_drift, andre_drift_py))
+
+    annen_kost = sum_ub("7")
+    annen_kost_py = sum_py("7")
+    rows.append(_make_row("Annen kostnad", annen_kost, annen_kost_py))
+
+    finansinntekt = -sum_ub("80")
+    finansinntekt_py = -sum_py("80")
+    rows.append(_make_row("Finansinntekter", finansinntekt, finansinntekt_py))
+
+    finanskost = sum_ub("81")
+    finanskost_py = sum_py("81")
+    rows.append(_make_row("Finanskostnader", finanskost, finanskost_py))
+
+    resultat_for_skatt = (
+        sum_salg_total
+        - varekostnad
+        - lonn
+        - avskr
+        - andre_drift
+        - annen_kost
+        + finansinntekt
+        - finanskost
+    )
+    resultat_for_skatt_py = (
+        sum_salg_total_py
+        - varekostnad_py
+        - lonn_py
+        - avskr_py
+        - andre_drift_py
+        - annen_kost_py
+        + finansinntekt_py
+        - finanskost_py
+    )
+    rows.append(_make_row("Resultat før skatt", resultat_for_skatt, resultat_for_skatt_py))
+
+    return rows
+
+
+__all__ = [
+    "AnalysisRow",
+    "prepare_regnskap_dataframe",
+    "compute_balance_analysis",
+    "compute_result_analysis",
+]
+

--- a/tests/test_regnskap_analysis.py
+++ b/tests/test_regnskap_analysis.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nordlys.regnskap import (
+    AnalysisRow,
+    compute_balance_analysis,
+    compute_result_analysis,
+    prepare_regnskap_dataframe,
+)
+
+
+def build_sample_tb() -> pd.DataFrame:
+    rows = [
+        {"Konto": "1000", "Kontonavn": "Immaterielle", "IB Debet": 50, "UB Debet": 60},
+        {"Konto": "1100", "Kontonavn": "Tomter", "IB Debet": 100, "UB Debet": 120},
+        {"Konto": "1200", "Kontonavn": "Maskiner", "IB Debet": 80, "UB Debet": 90},
+        {"Konto": "1300", "Kontonavn": "Finansielle anlegg", "IB Debet": 40, "UB Debet": 55},
+        {"Konto": "1400", "Kontonavn": "Varelager", "IB Debet": 200, "UB Debet": 220},
+        {"Konto": "1500", "Kontonavn": "Kundefordringer", "IB Debet": 150, "UB Debet": 180},
+        {"Konto": "1580", "Kontonavn": "Avsetning tap", "IB Debet": 20, "UB Debet": 30},
+        {"Konto": "1505", "Kontonavn": "Andre fordringer", "IB Debet": 30, "UB Debet": 40},
+        {"Konto": "1600", "Kontonavn": "MVA", "IB Debet": 10, "UB Debet": 15},
+        {"Konto": "1700", "Kontonavn": "Forskudd", "IB Debet": 5, "UB Debet": 7},
+        {"Konto": "1800", "Kontonavn": "Finansielle", "IB Debet": 12, "UB Debet": 20},
+        {"Konto": "1900", "Kontonavn": "Bank", "IB Debet": 300, "UB Debet": 350},
+        {"Konto": "2000", "Kontonavn": "Egenkapital", "IB Kredit": 750, "UB Kredit": 892},
+        {"Konto": "2100", "Kontonavn": "Avsetning", "IB Kredit": 28, "UB Kredit": 25},
+        {"Konto": "2200", "Kontonavn": "Langsiktig gjeld", "IB Kredit": 80, "UB Kredit": 100},
+        {"Konto": "2300", "Kontonavn": "Kortsiktig gjeld", "IB Kredit": 50, "UB Kredit": 70},
+        {"Konto": "2400", "Kontonavn": "Leverandørgjeld", "IB Kredit": 40, "UB Kredit": 50},
+        {"Konto": "2500", "Kontonavn": "Skyldig skattetrekk", "IB Kredit": 20, "UB Kredit": 15},
+        {"Konto": "2900", "Kontonavn": "Annen kortsiktig gjeld", "IB Kredit": 29, "UB Kredit": 35},
+        {"Konto": "3000", "Kontonavn": "Salgsinntekter", "IB Kredit": 900, "UB Kredit": 1000},
+        {"Konto": "3800", "Kontonavn": "Annen inntekt", "IB Kredit": 40, "UB Kredit": 50},
+        {"Konto": "3900", "Kontonavn": "Annen inntekt", "IB Kredit": 10, "UB Kredit": 20},
+        {"Konto": "4000", "Kontonavn": "Varekost", "IB Debet": 500, "UB Debet": 550},
+        {"Konto": "5000", "Kontonavn": "Lønn", "IB Debet": 200, "UB Debet": 220},
+        {"Konto": "6000", "Kontonavn": "Avskrivning", "IB Debet": 150, "UB Debet": 160},
+        {"Konto": "6100", "Kontonavn": "Andre driftskost", "IB Debet": 80, "UB Debet": 90},
+        {"Konto": "7000", "Kontonavn": "Annen kost", "IB Debet": 60, "UB Debet": 65},
+        {"Konto": "8000", "Kontonavn": "Finansinntekt", "IB Kredit": 30, "UB Kredit": 40},
+        {"Konto": "8100", "Kontonavn": "Finanskost", "IB Debet": 25, "UB Debet": 35},
+        {"Konto": "8300", "Kontonavn": "Skatt", "IB Kredit": 15, "UB Kredit": 18},
+    ]
+
+    for row in rows:
+        row.setdefault("IB Debet", 0.0)
+        row.setdefault("IB Kredit", 0.0)
+        row.setdefault("UB Debet", 0.0)
+        row.setdefault("UB Kredit", 0.0)
+
+    return pd.DataFrame(rows)
+
+
+def row_by_label(rows: list[AnalysisRow], label: str) -> AnalysisRow:
+    for row in rows:
+        if row.label == label:
+            return row
+    raise AssertionError(f"Fant ikke rad: {label}")
+
+
+def test_prepare_regnskap_dataframe_builds_expected_columns():
+    df = build_sample_tb()
+    prepared = prepare_regnskap_dataframe(df)
+    assert set(["konto", "navn", "IB", "endring", "UB", "forrige"]).issubset(prepared.columns)
+    first = prepared.iloc[0]
+    assert first["konto"] == "1000"
+    assert pytest.approx(first["UB"], rel=1e-6) == 60
+    assert pytest.approx(first["forrige"], rel=1e-6) == 50
+
+
+def test_compute_balance_analysis_matches_expected_totals():
+    prepared = prepare_regnskap_dataframe(build_sample_tb())
+    rows = compute_balance_analysis(prepared)
+
+    immaterielle = row_by_label(rows, "10 Immaterielle")
+    assert immaterielle.current == pytest.approx(60)
+    assert immaterielle.previous == pytest.approx(50)
+
+    kundefordr = row_by_label(rows, "Kundefordringer (netto)")
+    assert kundefordr.current == pytest.approx(210)
+    assert kundefordr.previous == pytest.approx(170)
+
+    korts_fordringer = row_by_label(rows, "Kortsiktige fordringer (øvrige)")
+    assert korts_fordringer.current == pytest.approx(40)
+    assert korts_fordringer.previous == pytest.approx(30)
+
+    kortsiktig_gjeld = row_by_label(rows, "Kortsiktig gjeld (23–29)")
+    assert kortsiktig_gjeld.current == pytest.approx(170)
+    assert kortsiktig_gjeld.previous == pytest.approx(139)
+
+    sum_eiendeler = row_by_label(rows, "Sum eiendeler")
+    sum_ek_gjeld = row_by_label(rows, "Sum EK og gjeld")
+    assert sum_eiendeler.current == pytest.approx(1187)
+    assert sum_ek_gjeld.current == pytest.approx(1187)
+    assert row_by_label(rows, "Differanse").current == pytest.approx(0)
+
+
+def test_compute_result_analysis_calculates_income_statement_lines():
+    prepared = prepare_regnskap_dataframe(build_sample_tb())
+    rows = compute_result_analysis(prepared)
+
+    annen_inntekt = row_by_label(rows, "Annen inntekt")
+    assert annen_inntekt.current == pytest.approx(70)
+    assert annen_inntekt.previous == pytest.approx(50)
+
+    salgsinntekter = row_by_label(rows, "Salgsinntekter (3xxx ekskl. 38/39)")
+    assert salgsinntekter.current == pytest.approx(1000)
+    assert salgsinntekter.previous == pytest.approx(900)
+
+    sum_inntekter = row_by_label(rows, "Sum inntekter")
+    assert sum_inntekter.current == pytest.approx(1070)
+    assert sum_inntekter.previous == pytest.approx(950)
+
+    resultat = row_by_label(rows, "Resultat før skatt")
+    assert resultat.current == pytest.approx(-10)
+    assert resultat.previous == pytest.approx(-35)


### PR DESCRIPTION
## Oppsummering
- legger til egne beregninger for balanse- og resultataggregater basert på kontonummer-prefikser
- bygger en ny regnskapsanalyseside som visualiserer balanse, resultat og Brreg-sammenligning fra SAF-T
- dekker beregningene med enhetstester for balanse- og resultatoppsummeringer

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_690766e4b8d88328acb2868006c03e48