### PR TITLE
Improve user authentication flow

### DIFF
--- a/nordlys/ui/pyside_app.py
+++ b/nordlys/ui/pyside_app.py
@@ -63,11 +63,7 @@ from ..saft import (
     parse_suppliers,
     validate_saft_against_xsd,
 )
-from ..saft_customers import (
-    compute_purchases_per_supplier,
-    compute_sales_per_customer,
-    parse_saft,
-)
+from ..saft_customers import compute_customer_supplier_totals, parse_saft
 from ..utils import format_currency, format_difference
 
 
@@ -216,13 +212,7 @@ class SaftLoadWorker(QObject):
             customer_sales: Optional[pd.DataFrame] = None
             supplier_purchases: Optional[pd.DataFrame] = None
             if period_start or period_end:
-                customer_sales = compute_sales_per_customer(
-                    root,
-                    ns,
-                    date_from=period_start,
-                    date_to=period_end,
-                )
-                supplier_purchases = compute_purchases_per_supplier(
+                customer_sales, supplier_purchases = compute_customer_supplier_totals(
                     root,
                     ns,
                     date_from=period_start,
@@ -248,8 +238,7 @@ class SaftLoadWorker(QObject):
                                 analysis_year = parsed.year
                                 break
                 if analysis_year is not None:
-                    customer_sales = compute_sales_per_customer(root, ns, year=analysis_year)
-                    supplier_purchases = compute_purchases_per_supplier(
+                    customer_sales, supplier_purchases = compute_customer_supplier_totals(
                         root,
                         ns,
                         year=analysis_year,

--- a/tests/test_saft.py
+++ b/tests/test_saft.py
@@ -18,6 +18,7 @@ from nordlys.saft import (
 from nordlys.saft_customers import (
     build_customer_name_map,
     build_supplier_name_map,
+    compute_customer_supplier_totals,
     compute_purchases_per_supplier,
     compute_sales_per_customer,
     get_amount,
@@ -314,6 +315,18 @@ def test_compute_purchases_per_supplier_date_filter():
     ns = {'n1': root.tag.split('}')[0][1:]}
     df = compute_purchases_per_supplier(root, ns, date_from='2023-07-01', date_to='2023-12-31')
     assert df.empty
+
+
+def test_compute_customer_supplier_totals_matches_individual():
+    root = build_sample_root()
+    ns = {'n1': root.tag.split('}')[0][1:]}
+    expected_sales = compute_sales_per_customer(root, ns, year=2023)
+    expected_purchases = compute_purchases_per_supplier(root, ns, year=2023)
+
+    sales, purchases = compute_customer_supplier_totals(root, ns, year=2023)
+
+    pd.testing.assert_frame_equal(sales, expected_sales)
+    pd.testing.assert_frame_equal(purchases, expected_purchases)
 
 
 def test_compute_purchases_includes_all_cost_accounts():


### PR DESCRIPTION
 - nordlys/saft_customers.py (line 164) & 231 – la til valgfri lines-parameter i kunde-/leverandør-ID-logikken slik at samme linjeliste kan gjenbrukes uten ekstra _findall-pass.
 - nordlys/saft_customers.py (line 303), 311, 369 – introduserte _build_parent_map og deler nå parent-oppslag mellom navnmapper for å slippe to fulle tree-walks.
 - nordlys/saft_customers.py (line 466) – ny compute_customer_supplier_totals aggregerer salg og innkjøp i ett transaksjonspass og gjenbruker filtrerings-/avrundingslogikken.
 - nordlys/ui/pyside_app.py (line 214) – bakgrunnsarbeideren bruker den nye samlefunksjonen, så importen gjør ikke lenger to komplette transaksjonsrunder.
 - tests/test_saft.py (line 320) – la til regresjonstest som sikrer at den kombinerte aggregeringen matcher resultatene fra de eksisterende hjelpefunksjonene.