### PR TITLE
Ny importside med logg

### DIFF
--- a/nordlys/resources/icons/import.svg
+++ b/nordlys/resources/icons/import.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#f8fafc" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3.5v10.5"/>
+  <polyline points="8.5 10.5 12 14 15.5 10.5"/>
+  <path d="M4.5 13.5h15v6a1.2 1.2 0 0 1-1.2 1.2H5.7a1.2 1.2 0 0 1-1.2-1.2z"/>
+</svg>


### PR DESCRIPTION
Introduced a dedicated Import-side som viser status, bransjeinnsikt og en ny logg mens dashboardet får fokus på analyse.

 - nordlys/ui/pyside_app.py (lines 406-551) oppretter ImportPage med status-/brreg-seksjoner og et romslig QPlainTextEdit loggfelt, samt flytter de tidligere dashboard-metodene hit.
 - nordlys/ui/pyside_app.py (lines 554-616) beholder DashboardPage for KPI- og sammendragskort uten status/blokkene.
 - nordlys/ui/pyside_app.py (lines 115-131), 1445-1467, 1520-1820, 1881-2149 kobler på nytt nav-punkt for Import (med ikon), gjør Import til startsiden, logger import-/eksport-hendelser via _log_import_event, og sørger for at status-, brreg- og valideringsoppdateringer treffer den nye siden.
 - nordlys/resources/icons/import.svg legger til et matchende import-ikon for navigasjonen.