### PR TITLE
Rett avrunding av negative tall i regnskapsanalyse

### DIFF
--- a/nordlys/regnskap.py
+++ b/nordlys/regnskap.py
@@ -146,9 +146,11 @@ def _clean_value(value: float) -> float:
 
     try:
         decimal_value = Decimal(str(numeric))
-        rounding_mode = ROUND_UP if decimal_value < 0 else ROUND_HALF_UP
-        quantized = decimal_value.quantize(Decimal("1"), rounding=rounding_mode)
+        quantized = decimal_value.quantize(Decimal("1"), rounding=ROUND_HALF_UP)
     except (InvalidOperation, ValueError):
+        return 0.0
+
+    if quantized == 0:
         return 0.0
 
     return float(quantized)

--- a/tests/test_regnskap_analysis.py
+++ b/tests/test_regnskap_analysis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+import nordlys.regnskap as regnskap
 from nordlys.regnskap import (
     AnalysisRow,
     compute_balance_analysis,
@@ -119,7 +120,7 @@ def test_compute_result_analysis_calculates_income_statement_lines():
     assert resultat.previous == pytest.approx(-35)
 
 
-def test_compute_result_analysis_rounds_negative_values_away_from_zero():
+def test_compute_result_analysis_rounds_negative_values_to_nearest_integer():
     df = pd.DataFrame(
         [
             {
@@ -144,4 +145,12 @@ def test_compute_result_analysis_rounds_negative_values_away_from_zero():
     prepared = prepare_regnskap_dataframe(df)
     rows = compute_result_analysis(prepared)
     resultat = row_by_label(rows, "Resultat før skatt")
-    assert resultat.current == -151
+    assert resultat.current == -150
+
+
+def test_clean_value_rounds_negative_numbers_to_nearest_integer():
+    """Sikrer symmetrisk avrunding for negative verdier."""
+
+    value = regnskap._clean_value(-100.2)
+
+    assert value == -100


### PR DESCRIPTION
## Sammendrag
- sørget for at `_clean_value` bruker symmetrisk avrunding slik at negative tall ikke lenger blir gjort mer negative
- oppdaterte og utvidet testene for regnskapsanalysen slik at de dekker den korrigerte avrundingen

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690db798d314832888be7b0a7d448d98)