### PR TITLE
Utsett pandas-import til første bruk

### DIFF
--- a/nordlys/regnskap.py
+++ b/nordlys/regnskap.py
@@ -2,12 +2,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Iterable, List, Optional
+from typing import Callable, Iterable, List, Optional, TYPE_CHECKING
 
 import math
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP, ROUND_UP
 
-import pandas as pd
+from .utils import lazy_pandas
+
+if TYPE_CHECKING:  # pragma: no cover - kun for typekontroll
+    import pandas as pd
+
+pd = lazy_pandas()
 
 
 @dataclass(frozen=True)

--- a/nordlys/saft.py
+++ b/nordlys/saft.py
@@ -5,14 +5,17 @@ import importlib
 import importlib.util
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING
 import xml.etree.ElementTree as ET
 import re
 
-import pandas as pd
-
 from .constants import NS
-from .utils import text_or_none, to_float
+from .utils import lazy_pandas, text_or_none, to_float
+
+if TYPE_CHECKING:  # pragma: no cover - kun for typekontroll
+    import pandas as pd
+
+pd = lazy_pandas()
 
 
 _XMLSCHEMA_SPEC = importlib.util.find_spec("xmlschema")

--- a/nordlys/saft_customers.py
+++ b/nordlys/saft_customers.py
@@ -6,12 +6,17 @@ from datetime import date, datetime
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 import numbers
 from pathlib import Path
-from typing import Dict, Iterable, Optional, Tuple
+from typing import Dict, Iterable, Optional, Tuple, TYPE_CHECKING
 import xml.etree.ElementTree as ET
 from xml.sax.saxutils import escape
 import zipfile
 
-import pandas as pd
+from .utils import lazy_pandas
+
+if TYPE_CHECKING:  # pragma: no cover - kun for typekontroll
+    import pandas as pd
+
+pd = lazy_pandas()
 
 
 _NS_FLAG_KEY = "__has_namespace__"

--- a/nordlys/ui/pyside_app.py
+++ b/nordlys/ui/pyside_app.py
@@ -8,9 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, cast
-
-import pandas as pd
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, TYPE_CHECKING, cast
 from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot, QTimer
 from PySide6.QtGui import QBrush, QColor, QFont, QIcon, QTextCursor, QPen
 from PySide6.QtWidgets import (
@@ -72,7 +70,12 @@ from ..saft import (
     validate_saft_against_xsd,
 )
 from ..saft_customers import compute_customer_supplier_totals, parse_saft
-from ..utils import format_currency, format_difference
+from ..utils import format_currency, format_difference, lazy_pandas
+
+if TYPE_CHECKING:  # pragma: no cover - kun for typekontroll
+    import pandas as pd
+
+pd = lazy_pandas()
 
 
 REVISION_TASKS: Dict[str, List[str]] = {

--- a/nordlys/utils.py
+++ b/nordlys/utils.py
@@ -1,9 +1,52 @@
 """Generelle hjelpefunksjoner for konvertering og formatering."""
 from __future__ import annotations
 
-from typing import List, Optional
+from importlib import import_module
+from types import ModuleType
+from typing import Any, List, Optional, TYPE_CHECKING, cast
 
 import xml.etree.ElementTree as ET
+
+if TYPE_CHECKING:  # pragma: no cover - kun for typekontroll
+    import pandas as pd
+
+
+class _LazyModule(ModuleType):
+    """En enkel proxy som laster moduler på første bruk."""
+
+    def __init__(self, module_name: str) -> None:
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module: Optional[ModuleType] = None
+
+    def _load(self) -> ModuleType:
+        if self._module is None:
+            self._module = import_module(self._module_name)
+        return self._module
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._load(), item)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key in {"_module_name", "_module"}:
+            super().__setattr__(key, value)
+        else:
+            setattr(self._load(), key, value)
+
+    def __dir__(self) -> List[str]:
+        return dir(self._load())
+
+
+_PANDAS_PROXY: Optional[_LazyModule] = None
+
+
+def lazy_pandas() -> "pd":
+    """Returnerer en proxy som importerer ``pandas`` først når den brukes."""
+
+    global _PANDAS_PROXY
+    if _PANDAS_PROXY is None:
+        _PANDAS_PROXY = _LazyModule("pandas")
+    return cast("pd", _PANDAS_PROXY)
 
 
 def to_float(value: Optional[str]) -> float:
@@ -97,4 +140,5 @@ __all__ = [
     "findall_any_namespace",
     "format_currency",
     "format_difference",
+    "lazy_pandas",
 ]


### PR DESCRIPTION
## Sammendrag
- la til en generell "lazy"-proxy for pandas slik at biblioteket først importeres når det trengs
- oppdaterte SAF-T-, regnskaps- og GUI-moduler til å bruke proxyen for å slippe kostbar import ved oppstart

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e30ffb6508328a09a0ea49a2770b7)