### PR TITLE
Støtt etterhengende minustegn i to_float

### DIFF
--- a/nordlys/utils.py
+++ b/nordlys/utils.py
@@ -72,6 +72,13 @@ def to_float(value: Optional[str]) -> float:
     sign = ""
     if cleaned[0] in "+-":
         sign, cleaned = cleaned[0], cleaned[1:]
+    elif cleaned[-1] in "+-":
+        sign = cleaned[-1]
+        cleaned = cleaned[:-1]
+
+    cleaned = cleaned.strip()
+    if not cleaned:
+        return 0.0
 
     comma_pos = cleaned.rfind(",")
     dot_pos = cleaned.rfind(".")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ from nordlys.utils import to_float
         ("1.234", 1.234),
         ("123.4567", 123.4567),
         (1234, 1234.0),
+        ("1 234,50-", -1234.5),
     ],
 )
 def test_to_float_handles_common_separators(value, expected):


### PR DESCRIPTION
## Sammendrag
- gjør numerisk parseren i `to_float` robust mot minus-tegn som står bak tallet
- legger til enhetstest som dekker det nye formatet

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910cfdba5a083288bd14fd3bc7252d1)