### PR TITLE
Gjør nordlys-importen raskere med late moduler

### DIFF
--- a/nordlys/__init__.py
+++ b/nordlys/__init__.py
@@ -1,6 +1,10 @@
 """Nordlys-bibliotekets grensesnitt."""
 
-from . import brreg, industry_groups, saft, utils
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
 from .constants import APP_TITLE, BRREG_URL_TMPL, ENHETSREGISTER_URL_TMPL, NS
 
 __all__ = [
@@ -13,3 +17,24 @@ __all__ = [
     'saft',
     'utils',
 ]
+
+_MODULE_MAP = {
+    'brreg': 'nordlys.brreg',
+    'industry_groups': 'nordlys.industry_groups',
+    'saft': 'nordlys.saft',
+    'utils': 'nordlys.utils',
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Last moduler først når de faktisk brukes."""
+
+    if name in _MODULE_MAP:
+        module = import_module(_MODULE_MAP[name])
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module 'nordlys' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__ + list(globals().keys())))


### PR DESCRIPTION
## Sammendrag
- flytter import av tunge delmoduler til __getattr__ slik at de lastes på første bruk
- bevarer offentlige konstanter og eksportert API uendret

## Testing
- `pytest`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f9df2bb88328acee6ed6a0bf1309)