### PR TITLE
CardFrame update

### DIFF
--- a/nordlys/ui/pyside_app.py
+++ b/nordlys/ui/pyside_app.py
@@ -536,7 +536,9 @@ class CardFrame(QFrame):
             self.body_layout.setStretchFactor(widget, 100)
 
     def _maybe_mark_expanding_layout(self, sub_layout: QHBoxLayout | QVBoxLayout | QGridLayout) -> None:
-        if sub_layout.sizeConstraint() != QLayout.SetFixedSize:
+        if sub_layout.sizeConstraint() == QLayout.SetFixedSize:
+            return
+        if sub_layout.expandingDirections() & Qt.Vertical:
             self.body_layout.setStretchFactor(sub_layout, 100)
 
     def add_widget(self, widget: QWidget) -> None:


### PR DESCRIPTION
CardFrame update

Added a persistent stretch at the bottom of every card body and route all later widgets/layouts through insertWidget/insertLayout, guaranteeing that anything added via add_widget() lands immediately under the subtitle (nordlys/ui/pyside_app.py (lines 515-548)).
To keep non-import pages stretching as before, new helpers tag any non-QLabel widget/layout with an Expanding, MinimumExpanding, or Ignored vertical policy so the layout gives them a high stretch factor; they now reclaim the available height even though the footer stretch remains present (nordlys/ui/pyside_app.py (lines 525-548)).
With this, the import cards lose the unwanted gap, while tables, splitters, logs, etc., elsewhere continue filling the window.