### PR TITLE
Forklar pytest-import i test_utils

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import pytest
+import pytest  # pytest trengs for parametrisering og approx-sammenligning
 
 from nordlys.utils import format_currency, format_difference, to_float
 


### PR DESCRIPTION
## Oppsummering
- la til en forklarende kommentar på `import pytest` slik at det er tydelig hvorfor importen trengs i testene

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916093c0d2c8328a591cf99867e774b)