### PR TITLE
Legg til retry og bedre feilhåndtering mot Brreg

### DIFF
--- a/nordlys/brreg.py
+++ b/nordlys/brreg.py
@@ -4,17 +4,56 @@ from __future__ import annotations
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from .constants import BRREG_URL_TMPL
+
+
+_SESSION: Optional[requests.Session] = None
+
+
+def _get_session() -> requests.Session:
+    """Returnerer en requests-session med retry-oppsett."""
+
+    global _SESSION
+    if _SESSION is None:
+        retry = Retry(
+            total=3,
+            connect=3,
+            read=3,
+            status=3,
+            backoff_factor=1,
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=("GET",),
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session = requests.Session()
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        _SESSION = session
+    assert _SESSION is not None
+    return _SESSION
 
 
 def fetch_brreg(orgnr: str) -> Tuple[Optional[Dict[str, object]], Optional[str]]:
     """Henter JSON-data for angitt organisasjonsnummer."""
     url = BRREG_URL_TMPL.format(orgnr=orgnr)
+    session = _get_session()
     try:
-        response = requests.get(url, headers={'Accept': 'application/json'}, timeout=20)
+        response = session.get(url, headers={'Accept': 'application/json'}, timeout=20)
         response.raise_for_status()
         return response.json(), None
+    except requests.Timeout:
+        return None, (
+            'Kunne ikke hente data fra Brønnøysundregistrene på grunn av tidsavbrudd. '
+            'Vennligst prøv igjen litt senere.'
+        )
+    except requests.ConnectionError as exc:
+        return None, (
+            'Feil ved tilkobling mot Brønnøysundregistrene. '
+            f'Detaljer: {exc}'
+        )
     except requests.RequestException as exc:
         return None, str(exc)
     except ValueError as exc:

--- a/tests/test_brreg.py
+++ b/tests/test_brreg.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import requests
+
+from nordlys import brreg
 from nordlys.brreg import find_first_by_exact_endkey, map_brreg_metrics
 
 
@@ -71,3 +74,16 @@ def test_map_brreg_metrics():
     assert mapped['driftsinntekter'] == 123
     assert mapped['arsresultat'] == 45
     assert mapped['ebit'] == 40
+
+
+def test_fetch_brreg_timeout(monkeypatch):
+    class DummySession:
+        def get(self, *args, **kwargs):
+            raise requests.Timeout("test-timeout")
+
+    monkeypatch.setattr(brreg, '_SESSION', DummySession(), raising=False)
+
+    data, error = brreg.fetch_brreg('123456789')
+
+    assert data is None
+    assert 'tidsavbrudd' in error.lower()


### PR DESCRIPTION
## Oppsummering
- legg til gjenbrukbar requests-session med retry mot Brønnøysundregistrene
- gi tydeligere feilmeldinger ved tidsavbrudd og tilkoblingsfeil
- legg til test som dekker tidsavbruddshåndteringen

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162632328883288e58cfe547c4790c)