### PR TITLE
Støtte for parenteser som negativt tegn i to_float

### DIFF
--- a/nordlys/utils.py
+++ b/nordlys/utils.py
@@ -67,11 +67,19 @@ def to_float(value: Optional[str]) -> float:
     if not cleaned:
         return 0.0
 
+    sign = ""
+    if cleaned.startswith("(") or cleaned.endswith(")"):
+        if not (cleaned.startswith("(") and cleaned.endswith(")")):
+            return 0.0
+        cleaned = cleaned[1:-1].strip()
+        if not cleaned:
+            return 0.0
+        sign = "-"
+
     allowed_chars = set("0123456789.,+-")
     if any(char not in allowed_chars for char in cleaned):
         return 0.0
 
-    sign = ""
     if cleaned[0] in "+-":
         sign, cleaned = cleaned[0], cleaned[1:]
     elif cleaned[-1] in "+-":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,10 @@ def test_to_float_handles_common_separators(value, expected):
     assert to_float(value) == pytest.approx(expected)
 
 
+def test_to_float_handles_parentheses_as_negative():
+    assert to_float("(1 234,50)") == pytest.approx(-1234.5)
+
+
 def test_to_float_invalid_returns_zero():
     assert to_float("not a number") == 0.0
 


### PR DESCRIPTION
## Sammendrag
- utvidet `to_float` til å tolke tall omgitt av parenteser som negative verdier
- la til en test som sikrer at parentesformatet tolkes riktig

## Testing
- `pytest tests/test_utils.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170501dd008328b33317cc551107b4)