### PR TITLE
Fjern macOS fra CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.11"]
 
     steps:


### PR DESCRIPTION
## Sammendrag
- Fjernet macOS fra testmatrisen i GitHub Actions, slik at bare Ubuntu og Windows kjører

## Testing
- Ikke kjørt (endring av CI-konfigurasjon)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917935a2f2c832898940bfdfe3064f9)