### PR TITLE
Rett opp standardverdier for kontotekst

### DIFF
--- a/nordlys/regnskap/prep.py
+++ b/nordlys/regnskap/prep.py
@@ -18,16 +18,18 @@ def prepare_regnskap_dataframe(df: "pd.DataFrame") -> "pd.DataFrame":
 
     work = df.copy()
 
-    for column in [
-        "Konto",
-        "Kontonavn",
-        "IB Debet",
-        "IB Kredit",
-        "UB Debet",
-        "UB Kredit",
-    ]:
+    required_defaults: dict[str, object] = {
+        "Konto": "",
+        "Kontonavn": "",
+        "IB Debet": 0.0,
+        "IB Kredit": 0.0,
+        "UB Debet": 0.0,
+        "UB Kredit": 0.0,
+    }
+
+    for column, default in required_defaults.items():
         if column not in work.columns:
-            work[column] = 0.0
+            work[column] = default
 
     konto_series = work["Konto"].fillna("").astype(str)
     navn_series = work.get("Kontonavn", "").fillna("")

--- a/tests/test_regnskap_analysis.py
+++ b/tests/test_regnskap_analysis.py
@@ -144,6 +144,25 @@ def test_prepare_regnskap_dataframe_builds_expected_columns():
     assert pytest.approx(first["forrige"], rel=1e-6) == 50
 
 
+def test_prepare_regnskap_dataframe_handles_missing_text_columns():
+    df = pd.DataFrame(
+        [
+            {
+                "IB Debet": 10.0,
+                "IB Kredit": 0.0,
+                "UB Debet": 12.0,
+                "UB Kredit": 0.0,
+            }
+        ]
+    )
+
+    prepared = prepare_regnskap_dataframe(df)
+
+    assert prepared.loc[0, "konto"] == ""
+    assert prepared.loc[0, "navn"] == ""
+    assert prepared.loc[0, "UB"] == pytest.approx(12.0)
+
+
 def test_compute_balance_analysis_matches_expected_totals():
     prepared = prepare_regnskap_dataframe(build_sample_tb())
     rows = compute_balance_analysis(prepared)


### PR DESCRIPTION
## Oppsummering
- sørger for at manglende kontotekster får tom streng i stedet for tallverdi
- legger til test som verifiserer håndtering av manglende tekstkolonner

## Tester
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69189847e5a883289c4ed4837c9ce6c8)