### PR TITLE
Fiks toppkunder

### DIFF
--- a/nordlys/ui/data_controller/analytics.py
+++ b/nordlys/ui/data_controller/analytics.py
@@ -28,6 +28,15 @@ class AnalyticsEventHandler:
             )
             return None
         self._context.status_bar.showMessage(f"Topp kunder (3xxx) beregnet. N={topn}.")
+        if rows is not None and len(rows) < topn:
+            QMessageBox.information(
+                self._context.parent,
+                "Færre kunder enn ønsket",
+                (
+                    "Datasettet inneholder færre kunder enn etterspurt. "
+                    f"Viser {len(rows)} av {topn}."
+                ),
+            )
         return rows
 
     def on_calc_top_suppliers(
@@ -44,4 +53,13 @@ class AnalyticsEventHandler:
         self._context.status_bar.showMessage(
             f"Innkjøp per leverandør (kostnadskonti 4xxx–8xxx) beregnet. N={topn}."
         )
+        if rows is not None and len(rows) < topn:
+            QMessageBox.information(
+                self._context.parent,
+                "Færre leverandører enn ønsket",
+                (
+                    "Datasettet inneholder færre leverandører enn etterspurt. "
+                    f"Viser {len(rows)} av {topn}."
+                ),
+            )
         return rows

--- a/nordlys/ui/pages/revision_pages.py
+++ b/nordlys/ui/pages/revision_pages.py
@@ -38,6 +38,14 @@ __all__ = [
 ]
 
 
+def _requested_top_count(spin_box: QSpinBox) -> int:
+    """Returner brukers valg etter at spinboxen har tolket inndata."""
+
+    spin_box.interpretText()
+    value = spin_box.value()
+    return max(spin_box.minimum(), min(spin_box.maximum(), value))
+
+
 @dataclass
 class VoucherReviewResult:
     """Resultat fra vurdering av et enkelt bilag."""
@@ -863,8 +871,8 @@ class SalesArPage(QWidget):
         controls.setSpacing(12)
         controls.addWidget(QLabel("Antall:"))
         self.top_spin = QSpinBox()
-        self.top_spin.setRange(5, 100)
-        self.top_spin.setValue(10)
+        self.top_spin.setRange(1, 9999)
+        self.top_spin.setValue(self.top_spin.minimum())
         controls.addWidget(self.top_spin)
         controls.addStretch(1)
         self.calc_button = QPushButton("Beregn topp kunder")
@@ -891,6 +899,9 @@ class SalesArPage(QWidget):
                 "Omsetning (eks. mva)",
             ]
         )
+        self.top_table.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeToContents
+        )
         self.top_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.top_table.hide()
 
@@ -902,7 +913,7 @@ class SalesArPage(QWidget):
         self.set_controls_enabled(False)
 
     def _handle_calc_clicked(self) -> None:
-        rows = self._on_calc_top("3xxx", int(self.top_spin.value()))
+        rows = self._on_calc_top("3xxx", _requested_top_count(self.top_spin))
         if rows:
             self.set_top_customers(rows)
 
@@ -954,8 +965,8 @@ class PurchasesApPage(QWidget):
         controls.setSpacing(12)
         controls.addWidget(QLabel("Antall:"))
         self.top_spin = QSpinBox()
-        self.top_spin.setRange(5, 100)
-        self.top_spin.setValue(10)
+        self.top_spin.setRange(1, 9999)
+        self.top_spin.setValue(self.top_spin.minimum())
         controls.addWidget(self.top_spin)
         controls.addStretch(1)
         self.calc_button = QPushButton("Beregn innkjøp per leverandør")
@@ -995,7 +1006,7 @@ class PurchasesApPage(QWidget):
         self.set_controls_enabled(False)
 
     def _handle_calc_clicked(self) -> None:
-        rows = self._on_calc_top("kostnadskonti", int(self.top_spin.value()))
+        rows = self._on_calc_top("kostnadskonti", _requested_top_count(self.top_spin))
         if rows:
             self.set_top_suppliers(rows)
 


### PR DESCRIPTION
Fjernet den (gamle) implicitte 5-begrensningen: begge “Antall”-feltene kan nå settes fra 1–9999, og vi leser kun den verdien spinboxen selv har tolket (ikke noen skjult default), så tall over 5 sendes videre.

Kunde-tabellen tilpasser nå kolonnebredden slik som leverandør-tabellen, slik at bredden ikke spriker og oppførslen speiler den som allerede fungerer.

Startverdien settes til minimum (1) slik at brukeren selv bestemmer antallet før beregning.