### PR TITLE
Fikset litt luft og tekst

### DIFF
--- a/nordlys/ui/pages/revision_pages.py
+++ b/nordlys/ui/pages/revision_pages.py
@@ -8,6 +8,7 @@ from typing import Callable, Iterable, List, Optional, Sequence, Tuple, cast
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QFileDialog,
+    QFrame,
     QGridLayout,
     QHeaderView,
     QHBoxLayout,
@@ -143,11 +144,14 @@ class CostVoucherReviewPage(QWidget):
         self.detail_card.add_widget(self.lbl_progress)
 
         meta_grid = QGridLayout()
-        meta_grid.setHorizontalSpacing(24)
-        meta_grid.setVerticalSpacing(8)
+        meta_grid.setContentsMargins(0, 0, 0, 0)
+        meta_grid.setHorizontalSpacing(16)
+        meta_grid.setVerticalSpacing(10)
+        meta_grid.setColumnStretch(0, 0)
+        meta_grid.setColumnStretch(1, 1)
         meta_labels = [
             ("Leverandør", "value_supplier"),
-            ("Dokument", "value_document"),
+            ("Bilag", "value_document"),
             ("Dato", "value_date"),
             ("Beløp (kostnad)", "value_amount"),
             ("Beskrivelse", "value_description"),
@@ -156,6 +160,7 @@ class CostVoucherReviewPage(QWidget):
         for row, (label_text, attr_name) in enumerate(meta_labels):
             label = QLabel(label_text)
             label.setObjectName("infoLabel")
+            label.setProperty("meta", True)
             meta_grid.addWidget(label, row, 0)
             value_label = QLabel("–")
             value_label.setObjectName("statusLabel")
@@ -163,7 +168,17 @@ class CostVoucherReviewPage(QWidget):
             meta_grid.addWidget(value_label, row, 1)
             setattr(self, attr_name, value_label)
 
-        self.detail_card.add_layout(meta_grid)
+        meta_section = QWidget()
+        meta_section_layout = QVBoxLayout(meta_section)
+        meta_section_layout.setContentsMargins(0, 0, 0, 0)
+        meta_section_layout.setSpacing(8)
+        meta_section_layout.addLayout(meta_grid)
+        self.detail_card.add_widget(meta_section)
+
+        divider = QFrame()
+        divider.setObjectName("analysisDivider")
+        divider.setFixedHeight(4)
+        self.detail_card.add_widget(divider)
 
         self.value_status = cast(QLabel, getattr(self, "value_status"))
         self._update_status_display(None)

--- a/nordlys/ui/styles.py
+++ b/nordlys/ui/styles.py
@@ -37,9 +37,19 @@ QPushButton#exportPdfButton:pressed { background-color: #c2410c; }
 #pageTitle { font-size: 30px; font-weight: 800; color: #0f172a; letter-spacing: 0.6px; }
 QLabel#pageSubtitle { color: #1e293b; font-size: 15px; }
 #statusLabel { color: #1f2937; font-size: 14px; line-height: 1.6; }
-QLabel[statusState='approved'] { color: #166534; font-weight: 600; }
-QLabel[statusState='rejected'] { color: #b91c1c; font-weight: 600; }
-QLabel[statusState='pending'] { color: #64748b; font-weight: 500; }
+QLabel[meta='true'] { font-weight: 600; }
+QLabel#statusLabel[statusState='approved'] {
+    color: #166534;
+    font-weight: 700;
+}
+QLabel#statusLabel[statusState='rejected'] {
+    color: #b91c1c;
+    font-weight: 700;
+}
+QLabel#statusLabel[statusState='pending'] {
+    color: #64748b;
+    font-weight: 500;
+}
 #emptyState { background-color: rgba(148, 163, 184, 0.12); border-radius: 18px; border: 1px dashed rgba(148, 163, 184, 0.4); }
 #emptyStateIcon { font-size: 32px; }
 #emptyStateTitle { font-size: 17px; font-weight: 600; color: #0f172a; }


### PR DESCRIPTION
Tett metadata-seksjonen i CostVoucherReviewPage ved å pakke QGridLayout inn i et eget meta_section, trimme horisontale mellomrom og la kolonnene strekke seg slik at bilagsdetaljene får jevn luft og ser pent arrangerte ut (nordlys/ui/pages/revision_pages.py (lines 146-204)).

Bruker QFrame-basert analysisDivider-stil for å skille metadata fra linjetabellen og importerer QFrame slik at deleren får riktig styling og høyde (nordlys/ui/pages/revision_pages.py (lines 9-27), nordlys/ui/pages/revision_pages.py (lines 170-181)).