### PR TITLE
Bruk mellomrom som tusenskille i visningen

### DIFF
--- a/nordlys/helpers/formatting.py
+++ b/nordlys/helpers/formatting.py
@@ -30,13 +30,19 @@ def _round_half_up(value: Optional[float]) -> Optional[int]:
     return int(quantized)
 
 
+def _format_thousands(value: int) -> str:
+    """Formaterer heltall med mellomrom som tusenskille."""
+
+    return f"{value:,}".replace(",", " ")
+
+
 def format_currency(value: Optional[float]) -> str:
-    """Formatterer beløp til heltall med tusenskilletegn."""
+    """Formatterer beløp til heltall med mellomrom som tusenskilletegn."""
 
     rounded = _round_half_up(value)
     if rounded is None:
         return "—"
-    return f"{rounded:,.0f}"
+    return _format_thousands(rounded)
 
 
 def format_difference(a: Optional[float], b: Optional[float]) -> str:
@@ -56,7 +62,7 @@ def format_difference(a: Optional[float], b: Optional[float]) -> str:
     rounded = _round_half_up(difference)
     if rounded is None:
         return "—"
-    return f"{rounded:,.0f}"
+    return _format_thousands(rounded)
 
 
 __all__ = ["format_currency", "format_difference"]

--- a/tests/test_saft.py
+++ b/tests/test_saft.py
@@ -1575,7 +1575,7 @@ def test_save_outputs_faller_til_xlsxwriter(tmp_path, monkeypatch):
 
 
 def test_format_helpers():
-    assert format_currency(1234.5) == "1,235"
+    assert format_currency(1234.5) == "1 235"
     assert format_difference(2000, 1500) == "500"
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,7 +43,8 @@ def test_format_currency_invalid() -> None:
 def test_format_currency_rounding() -> None:
     assert format_currency(2.5) == "3"
     assert format_currency(-2.5) == "-3"
-    assert format_currency(1234.5) == "1,235"
+    assert format_currency(1234.5) == "1 235"
+    assert format_currency(4163652) == "4 163 652"
 
 
 def test_format_difference_valid() -> None:


### PR DESCRIPTION
## Oppsummering
- oppdaterte format_currency og format_difference slik at alle tall vises med mellomrom som tusenskille
- oppdaterte testene til å dekke det nye formatet og la til en kontroll for syvsifrede beløp

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691caf43b4408328b1ea6b2fd6cbf9a5)