### PR TITLE
Harmoniser multiårstabellen for resultat

### DIFF
--- a/nordlys/ui/pages/regnskapsanalyse_page.py
+++ b/nordlys/ui/pages/regnskapsanalyse_page.py
@@ -470,8 +470,6 @@ class RegnskapsanalysePage(QWidget):
         row_specs.append(("Finansinntekter", _values_for("finansinntekter")))
         row_specs.append(("Finanskostnader", _values_for("finanskostnader")))
         row_specs.append(("Resultat før skatt", _values_for("resultat_for_skatt")))
-        row_specs.append(("Skattekostnad", _values_for("skattekostnad")))
-        row_specs.append(("Årsresultat", _values_for("arsresultat")))
 
         rows: List[List[object]] = []
         for label, values in row_specs:


### PR DESCRIPTION
## Endringer
- Fjernet skatt- og årsresultatrader fra multiårstabellen slik at «Resultat flere år»-seksjonen stopper ved «Resultat før skatt», på lik linje med «Siste 2 år».

## Tester
- `pytest tests/test_regnskap_analysis.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dea37df748328b4a36165a6000da5)