### PR TITLE
Flyttet rekkefølgen

### DIFF
--- a/nordlys/regnskap/analysis.py
+++ b/nordlys/regnskap/analysis.py
@@ -240,17 +240,15 @@ def compute_result_analysis(prepared: "pd.DataFrame") -> List[AnalysisRow]:
         return sum_column_by_prefix(work, "forrige", prefixes)
 
     rows: List[AnalysisRow] = []
-    rows.append(_make_header("Resultat"))
-
-    annen_inntekt = -(sum_ub("38") + sum_ub("39"))
-    annen_inntekt_py = -(sum_py("38") + sum_py("39"))
-    rows.append(_make_row("Annen inntekt", annen_inntekt, annen_inntekt_py))
 
     sum_salg_total = -sum_ub("3")
     sum_salg_total_py = -sum_py("3")
+    annen_inntekt = -(sum_ub("38") + sum_ub("39"))
+    annen_inntekt_py = -(sum_py("38") + sum_py("39"))
     salg = sum_salg_total - annen_inntekt
     salg_py = sum_salg_total_py - annen_inntekt_py
     rows.append(_make_row("Salgsinntekter", salg, salg_py))
+    rows.append(_make_row("Annen inntekt", annen_inntekt, annen_inntekt_py))
 
     rows.append(_make_row("Sum inntekter", sum_salg_total, sum_salg_total_py))
 


### PR DESCRIPTION
Flyttet rekkefølgen og oppdatert layout i resultatvisningene.

nordlys/regnskap/analysis.py: Salgsinntekter legges nå før Annen inntekt i beregnet resultat, slik at tabellene får riktig sortering.
nordlys/ui/pages/regnskapsanalyse_page.py: La inn mellomromsrader etter Sum inntekter og Annen kostnad, la til uthevede understreker for Salgsinntekter og Finanskostnader, og boldet hovedsummer. Samme rekkefølge/gap brukes nå også i “Resultat flere år”.