### PR TITLE
Legg til test for namespaces i findall_any_namespace

### DIFF
--- a/nordlys/helpers/xml_helpers.py
+++ b/nordlys/helpers/xml_helpers.py
@@ -19,7 +19,8 @@ def findall_any_namespace(inv: ET.Element, localname: str) -> List[ET.Element]:
 
     matches: List[ET.Element] = []
     for elem in inv.iter():
-        if elem.tag.split("}")[-1].lower() == localname.lower():
+        stripped_tag = elem.tag.split("}")[-1].split(":")[-1]
+        if stripped_tag.lower() == localname.lower():
             matches.append(elem)
     return matches
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import xml.etree.ElementTree as ET
+
 import pytest
 
 from nordlys.helpers.formatting import format_currency, format_difference
 from nordlys.helpers.number_parsing import to_float
+from nordlys.helpers.xml_helpers import findall_any_namespace
 
 
 @pytest.mark.parametrize(
@@ -61,3 +64,17 @@ def test_format_difference_invalid() -> None:
 def test_format_difference_rounding() -> None:
     assert format_difference(5.5, 0) == "6"
     assert format_difference(-5.5, 0) == "-6"
+
+
+def test_findall_any_namespace_handles_multiple_formats() -> None:
+    root = ET.Element("Root")
+    namespaced = ET.SubElement(root, "{http://example.com/ns}Tag")
+    prefixed = ET.SubElement(root, "n1:Tag")
+
+    matches = findall_any_namespace(root, "Tag")
+
+    assert len(matches) == 2
+    assert {element.tag for element in matches} == {
+        namespaced.tag,
+        prefixed.tag,
+    }


### PR DESCRIPTION
## Oppsummering
- la til en test som dekker både `{uri}Tag` og prefikset `n1:Tag`
- oppdaterte `findall_any_namespace` til å strippe både namespace og prefiks når den søker

## Tester
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217e1b80d883288dc68b9478d0af67)