### PR TITLE
Håndter prefiks i XML-hjelper

### DIFF
--- a/nordlys/helpers/xml_helpers.py
+++ b/nordlys/helpers/xml_helpers.py
@@ -19,7 +19,11 @@ def findall_any_namespace(inv: ET.Element, localname: str) -> List[ET.Element]:
 
     matches: List[ET.Element] = []
     for elem in inv.iter():
-        if elem.tag.split("}")[-1].lower() == localname.lower():
+        tag_localname = elem.tag.split("}")[-1]
+        if "}" not in elem.tag and ":" in elem.tag:
+            tag_localname = elem.tag.split(":")[-1]
+
+        if tag_localname.lower() == localname.lower():
             matches.append(elem)
     return matches
 

--- a/tests/test_xml_helpers.py
+++ b/tests/test_xml_helpers.py
@@ -1,0 +1,29 @@
+"""Tester for XML-hjelpefunksjoner."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from nordlys.helpers.xml_helpers import findall_any_namespace
+
+
+def test_finnes_med_standard_namespace() -> None:
+    root = ET.Element("root")
+    ET.SubElement(root, "{urn:test}Item")
+    ET.SubElement(root, "Item")
+
+    resultat = findall_any_namespace(root, "Item")
+
+    assert len(resultat) == 2
+    assert all(elem.tag.lower().endswith("item") for elem in resultat)
+
+
+def test_finnes_med_prefiks_uten_braces() -> None:
+    root = ET.Element("root")
+    ET.SubElement(root, "abc:Item")
+    ET.SubElement(root, "def:item")
+
+    resultat = findall_any_namespace(root, "item")
+
+    assert len(resultat) == 2
+    assert {elem.tag for elem in resultat} == {"abc:Item", "def:item"}


### PR DESCRIPTION
## Oppsummering
- Stripper nå prefiks med kolon når XML-taggen ikke har namespace-klammer
- Beholder case-insensitivt søk etter lokale navn
- La til enkle pytest-tester som dekker både namespace og prefiks-tagging

## Tester
- pytest tests/test_xml_helpers.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217e16530c8328bb90ea731b7fc596)