### PR TITLE
Oppdater Brreg-felt for tvangsoppløsning

### DIFF
--- a/nordlys/integrations/brreg_client.py
+++ b/nordlys/integrations/brreg_client.py
@@ -245,7 +245,7 @@ def get_company_status(orgnr: str) -> CompanyStatus:
     konkurs = _interpret_bool(data.get("konkurs"))
     under_avvikling = _interpret_bool(data.get("underAvvikling"))
     under_tvangsopplosning = _interpret_bool(
-        data.get("underTvangsavviklingEllerTvangsopplosning")
+        data.get("underTvangsavviklingEllerTvangsoppløsning")
     )
     avvik_candidates = [
         value

--- a/tests/test_brreg_service.py
+++ b/tests/test_brreg_service.py
@@ -34,7 +34,7 @@ def test_get_company_status_maps_flags(monkeypatch):
             data={
                 "konkurs": False,
                 "underAvvikling": "ja",
-                "underTvangsavviklingEllerTvangsopplosning": False,
+                "underTvangsavviklingEllerTvangsoppløsning": False,
                 "registrertIMvaregisteret": "J",
             },
             error_code=None,


### PR DESCRIPTION
## Oppsummering
- oppdaterer nøkkelnavnet for tvangsoppløsning til å samsvare med API-et
- justerer test og statuslesing til å bruke korrekt felt

## Testing
- pytest tests/test_brreg_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218fa661e08328b7ca6eae2e064f8a)