### PR TITLE
Håndter manglende prøvebalanse fra SAF-T

### DIFF
--- a/nordlys/saft/trial_balance.py
+++ b/nordlys/saft/trial_balance.py
@@ -39,6 +39,15 @@ def compute_trial_balance(file_path: str) -> TrialBalanceResult:
     except Exception as exc:  # pragma: no cover - robust mot eksterne feil
         return TrialBalanceResult(balance=None, error=str(exc))
 
+    if trial_balance is None:
+        return TrialBalanceResult(
+            balance=None,
+            error=(
+                "Kunne ikke beregne prøvebalanse: mottok ingen data for "
+                f"{Path(file_path).name}."
+            ),
+        )
+
     error: Optional[str] = None
     if trial_balance.get("diff") != Decimal("0"):
         error = "Prøvebalansen går ikke opp (diff {diff}) for {file}".format(

--- a/tests/test_trial_balance_module.py
+++ b/tests/test_trial_balance_module.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from nordlys.saft import trial_balance
+
+
+def test_compute_trial_balance_handles_none(monkeypatch, tmp_path):
+    dummy_file = tmp_path / "dummy.xml"
+    dummy_file.write_text("innhold")
+
+    monkeypatch.setattr(trial_balance, "SAFT_STREAMING_ENABLED", True)
+    monkeypatch.setattr(trial_balance, "SAFT_STREAMING_VALIDATE", False)
+    monkeypatch.setattr(
+        trial_balance.saft, "check_trial_balance", lambda *args, **kwargs: None
+    )
+
+    result = trial_balance.compute_trial_balance(str(dummy_file))
+
+    assert result.balance is None
+    assert result.error is not None
+    assert Path(dummy_file).name in result.error
+    assert "mottok ingen data" in result.error


### PR DESCRIPTION
## Sammendrag
- håndterer at `saft.check_trial_balance` kan returnere `None` og gir brukervennlig feilmelding
- legger til enhetstest som simulerer manglende prøvebalanse og verifiserer resultatet

## Testing
- `python -m pytest tests/test_trial_balance_module.py -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218fa6d2dc8328a42f96188792ad5b)