### PR TITLE
Forklar trådbegrensning ved import av store SAF-T-filer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Brønnøysundregistrene.
 
 - Import av én eller flere SAF-T-filer kjører i bakgrunnen via `TaskRunner`,
   med tydelig fremdrift og statusmeldinger i GUI-et.
+- Trådantallet under import begrenses automatisk til to når filene er store,
+  slik at minnebruken holder seg moderat.
 - Mulighet for strømming av hovedboken med miljøvariabelen
   `NORDLYS_SAFT_STREAMING=1`, slik at prøvebalansen sjekkes før hele filen er
   lest. Sett `NORDLYS_SAFT_STREAMING_VALIDATE=1` hvis du vil validere samtidig

--- a/nordlys/saft/loader.py
+++ b/nordlys/saft/loader.py
@@ -172,7 +172,9 @@ def load_saft_files(
     Laster en eller flere SAF-T-filer med fremdriftsrapportering.
 
     Funksjonen kan ta imot én eller flere filbaner og spinner opp en trådpool
-    med opptil én arbeider per CPU-kjerne.
+    med opptil én arbeider per CPU-kjerne. `_suggest_max_workers` senker
+    samtidig antallet til `HEAVY_SAFT_MAX_WORKERS` når filene er store for å
+    unngå minnepress.
     """
 
     if isinstance(file_paths, (str, os.PathLike)):


### PR DESCRIPTION
## Oppsummering
- Oppdaterte docstringen for `load_saft_files` slik at begrensningen via `_suggest_max_workers` og `HEAVY_SAFT_MAX_WORKERS` er tydelig.
- La til i README at import av store SAF-T-filer automatisk begrenses til to tråder for å holde minnebruken nede.

## Testing
- Ikke kjørt tester (kun dokumentasjonsendringer).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218fa8db8883288faebde64c2ca85f)