### PR TITLE
Legg til dummytest for _suggest_max_workers

### DIFF
--- a/tests/test_saft_loader.py
+++ b/tests/test_saft_loader.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+from pathlib import Path
+
+from nordlys.saft import loader
+
+
+def test_suggest_max_workers_caps_for_heavy_dummy_paths(monkeypatch):
+    size_map = {
+        "heavy_a": loader.HEAVY_SAFT_FILE_BYTES,
+        "heavy_b": loader.HEAVY_SAFT_FILE_BYTES + 1,
+        "heavy_c": loader.HEAVY_SAFT_FILE_BYTES * 2,
+    }
+
+    def fake_stat(self: Path) -> SimpleNamespace:
+        return SimpleNamespace(st_size=size_map.get(str(self), 0))
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+
+    dummy_paths = list(size_map)
+    suggested = loader._suggest_max_workers(dummy_paths, cpu_limit=8)
+
+    assert suggested == loader.HEAVY_SAFT_MAX_WORKERS


### PR DESCRIPTION
## Oppsummering
- legger til ny test som monkeypatcher Path.stat slik at store dummyfiler brukes
- sikrer at _suggest_max_workers returnerer HEAVY_SAFT_MAX_WORKERS når grenseverdier passeres

## Tester
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69218fab972c8328b4ddbbf1089fde89)