### PR TITLE
Fikset feil inne på analyse

### DIFF
--- a/nordlys/regnskap/analysis.py
+++ b/nordlys/regnskap/analysis.py
@@ -155,6 +155,8 @@ def compute_balance_analysis(prepared: "pd.DataFrame") -> List[AnalysisRow]:
     egenkapital_current = _value_or_zero(egenkapital_row.current)
     egenkapital_previous = _value_or_zero(egenkapital_row.previous)
 
+    ek_rows.append(_make_header("Langsiktig gjeld"))
+
     avsetninger = -sum_ub("21")
     avsetninger_py = -sum_py("21")
     avsetninger_row = _make_row(
@@ -164,7 +166,6 @@ def compute_balance_analysis(prepared: "pd.DataFrame") -> List[AnalysisRow]:
     avsetninger_current = _value_or_zero(avsetninger_row.current)
     avsetninger_previous = _value_or_zero(avsetninger_row.previous)
 
-    ek_rows.append(_make_header("Langsiktig gjeld"))
     annen_langsiktig = -sum_ub("22")
     annen_langsiktig_py = -sum_py("22")
     annen_langsiktig_row = _make_row(
@@ -174,8 +175,8 @@ def compute_balance_analysis(prepared: "pd.DataFrame") -> List[AnalysisRow]:
     annen_langsiktig_current = _value_or_zero(annen_langsiktig_row.current)
     annen_langsiktig_previous = _value_or_zero(annen_langsiktig_row.previous)
 
-    sum_langsiktig = annen_langsiktig_current
-    sum_langsiktig_py = annen_langsiktig_previous
+    sum_langsiktig = annen_langsiktig_current + avsetninger_current
+    sum_langsiktig_py = annen_langsiktig_previous + avsetninger_previous
     ek_rows.append(_make_row("Sum langsiktig gjeld", sum_langsiktig, sum_langsiktig_py))
 
     ek_rows.append(_make_header("Kortsiktig gjeld"))
@@ -203,15 +204,8 @@ def compute_balance_analysis(prepared: "pd.DataFrame") -> List[AnalysisRow]:
 
     ek_rows.append(_make_row("Sum kortsiktig gjeld", kortsiktig_sum, kortsiktig_sum_py))
 
-    sum_ek_gjeld = (
-        egenkapital_current + avsetninger_current + sum_langsiktig + kortsiktig_sum
-    )
-    sum_ek_gjeld_py = (
-        egenkapital_previous
-        + avsetninger_previous
-        + sum_langsiktig_py
-        + kortsiktig_sum_py
-    )
+    sum_ek_gjeld = egenkapital_current + sum_langsiktig + kortsiktig_sum
+    sum_ek_gjeld_py = egenkapital_previous + sum_langsiktig_py + kortsiktig_sum_py
 
     ek_rows.append(_make_row("Sum egenkapital og gjeld", sum_ek_gjeld, sum_ek_gjeld_py))
 

--- a/nordlys/ui/pages/regnskapsanalyse_page.py
+++ b/nordlys/ui/pages/regnskapsanalyse_page.py
@@ -311,6 +311,11 @@ class RegnskapsanalysePage(QWidget):
             previous = "I fjor"
         return current, previous
 
+    def _snapshot_column_label(self, snapshot: SummarySnapshot) -> str:
+        base_label = str(snapshot.year) if snapshot.year is not None else snapshot.label
+        label = base_label or "—"
+        return f"{label}*" if snapshot.is_current else label
+
     def _clear_balance_table(self) -> None:
         self.balance_table.hide()
         self.balance_table.setRowCount(0)
@@ -331,11 +336,19 @@ class RegnskapsanalysePage(QWidget):
         rows = regnskap.compute_balance_analysis(self._prepared_df)
         current_label, previous_label = self._year_headers()
         table_rows: List[Tuple[object, object, object, object]] = []
+        spacer_after_labels = {
+            "Sum eiendeler",
+            "Sum egenkapital og gjeld",
+            "Egenkapital",
+            "Sum langsiktig gjeld",
+        }
         for row in rows:
             if row.is_header:
                 table_rows.append((row.label, "", "", ""))
             else:
                 table_rows.append((row.label, row.current, row.previous, row.change))
+                if row.label in spacer_after_labels:
+                    table_rows.append(("", "", "", ""))
         populate_table(
             self.balance_table,
             ["Kategori", current_label, previous_label, "Endring"],
@@ -432,8 +445,7 @@ class RegnskapsanalysePage(QWidget):
             return
 
         columns = ["Kategori"] + [
-            f"{snapshot.label}*" if snapshot.is_current else snapshot.label
-            for snapshot in self._summary_history
+            self._snapshot_column_label(snapshot) for snapshot in self._summary_history
         ]
         table_rows = self._multi_year_value_rows()
 
@@ -859,6 +871,10 @@ class RegnskapsanalysePage(QWidget):
             "Avvik",
             "Sum eiendeler",
             "Sum egenkapital og gjeld",
+            "Sum kortsiktig gjeld",
+            "Langsiktig gjeld",
+            "Kortsiktig gjeld",
+            "Sum langsiktig gjeld",
         }
         bottom_border_labels = {
             "Eiendeler",
@@ -868,6 +884,9 @@ class RegnskapsanalysePage(QWidget):
             "Kortsiktig gjeld",
             "Sum eiendeler",
             "Sum egenkapital og gjeld",
+            "Sum kortsiktig gjeld",
+            "Langsiktig gjeld",
+            "Sum langsiktig gjeld",
         }
         top_border_labels = {"Eiendeler", "Sum eiendeler", "Sum egenkapital og gjeld"}
         table = self.balance_table


### PR DESCRIPTION
- Multiårstabellene i regnskapsanalysen bruker nå bare årstall som kolonneoverskrifter (stjernen beholdes for aktivt år) via ny helper i nordlys/ui/pages/regnskapsanalyse_page.py.
- La inn tomrad-separatorer i balansetabellen etter Sum eiendeler og Sum egenkapital og gjeld ved å generere ekstra blanke rader i nordlys/ui/pages/regnskapsanalyse_page.py.
- Gjorde Sum kortsiktig gjeld fet og ga den samme markering/bunnramme som øvrige sumrader i nordlys/ui/pages/regnskapsanalyse_page.py.
- Flyttet «Avsetninger for forpliktelser» til seksjonen «Langsiktig gjeld» og tok den med i beregningen av «Sum langsiktig gjeld» slik at totalsummer stemmer, se nordlys/regnskap/analysis.py.
- Justerte bold-styling i balansevisningen slik at «Langsiktig gjeld», «Kortsiktig gjeld» og «Sum langsiktig gjeld» vises med fet skrift, se nordlys/ui/pages/regnskapsanalyse_page.py.
- La inn blanke rader etter «Egenkapital» og «Sum langsiktig gjeld» i balanse-tabellen ved å utvide spacer-listen i nordlys/ui/pages/regnskapsanalyse_page.py.
- La til markering for bunnstrek på «Langsiktig gjeld» og «Sum langsiktig gjeld», slik at headeren og totalsummen får den fete streken under, i nordlys/ui/pages/regnskapsanalyse_page.py.

