### PR TITLE
Samle SAF-T-ekstraksjon og gjenbruk mellomresultater i analyser

### DIFF
--- a/nordlys/saft/customer_analysis.py
+++ b/nordlys/saft/customer_analysis.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Dict, List, MutableMapping, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, List, MutableMapping, Optional, Sequence, Tuple, TYPE_CHECKING
 import xml.etree.ElementTree as ET
 
 from ..helpers.lazy_imports import lazy_import, lazy_pandas
@@ -80,10 +80,15 @@ def build_customer_supplier_analysis(
     header: Optional["saft.SaftHeader"],
     root: ET.Element,
     ns: MutableMapping[str, object],
+    *,
+    parent_map: Optional[Dict[ET.Element, Optional[ET.Element]]] = None,
+    transactions: Optional[Sequence[ET.Element]] = None,
 ) -> CustomerSupplierAnalysis:
     """Analyser kunder og leverandører, og returner et samlet resultat."""
 
-    observed_start, observed_end = _detect_transaction_span(root, ns)
+    observed_start, observed_end = _detect_transaction_span(
+        root, ns, transactions=transactions
+    )
     analysis_year, parent_map = determine_analysis_year(
         header, root, ns, transaction_span=(observed_start, observed_end)
     )
@@ -116,6 +121,7 @@ def build_customer_supplier_analysis(
                     date_from=effective_start,
                     date_to=effective_end,
                     parent_map=parent_map,
+                    transactions=transactions,
                 )
             )
             cost_vouchers = saft_customers.extract_cost_vouchers(
@@ -124,6 +130,7 @@ def build_customer_supplier_analysis(
                 date_from=effective_start,
                 date_to=effective_end,
                 parent_map=parent_map,
+                transactions=transactions,
             )
             all_vouchers = saft_customers.extract_all_vouchers(
                 root,
@@ -131,6 +138,7 @@ def build_customer_supplier_analysis(
                 date_from=effective_start,
                 date_to=effective_end,
                 parent_map=parent_map,
+                transactions=transactions,
             )
         elif analysis_year is not None:
             customer_sales, supplier_purchases = (
@@ -139,6 +147,7 @@ def build_customer_supplier_analysis(
                     ns,
                     year=analysis_year,
                     parent_map=parent_map,
+                    transactions=transactions,
                 )
             )
             cost_vouchers = saft_customers.extract_cost_vouchers(
@@ -146,15 +155,21 @@ def build_customer_supplier_analysis(
                 ns,
                 year=analysis_year,
                 parent_map=parent_map,
+                transactions=transactions,
             )
             all_vouchers = saft_customers.extract_all_vouchers(
                 root,
                 ns,
                 year=analysis_year,
                 parent_map=parent_map,
+                transactions=transactions,
             )
         credit_notes = saft_customers.extract_credit_notes(
-            root, ns, months=(1, 2), year=analysis_year
+            root,
+            ns,
+            months=(1, 2),
+            year=analysis_year,
+            transactions=transactions,
         )
     elif analysis_year is not None:
         if parent_map is None:
@@ -165,6 +180,7 @@ def build_customer_supplier_analysis(
                 ns,
                 year=analysis_year,
                 parent_map=parent_map,
+                transactions=transactions,
             )
         )
         cost_vouchers = saft_customers.extract_cost_vouchers(
@@ -172,15 +188,21 @@ def build_customer_supplier_analysis(
             ns,
             year=analysis_year,
             parent_map=parent_map,
+            transactions=transactions,
         )
         all_vouchers = saft_customers.extract_all_vouchers(
             root,
             ns,
             year=analysis_year,
             parent_map=parent_map,
+            transactions=transactions,
         )
         credit_notes = saft_customers.extract_credit_notes(
-            root, ns, months=(1, 2), year=analysis_year
+            root,
+            ns,
+            months=(1, 2),
+            year=analysis_year,
+            transactions=transactions,
         )
 
     if has_transaction_dates:
@@ -190,10 +212,11 @@ def build_customer_supplier_analysis(
             date_from=effective_start,
             date_to=effective_end,
             year=analysis_year,
+            transactions=transactions,
         )
     else:
         sales_ar_correlation = saft_customers.analyze_sales_receivable_correlation(
-            root, ns, year=analysis_year
+            root, ns, year=analysis_year, transactions=transactions
         )
 
     return CustomerSupplierAnalysis(
@@ -214,7 +237,10 @@ def _parse_date(value: Optional[str]) -> Optional[date]:
 
 
 def _detect_transaction_span(
-    root: ET.Element, ns: MutableMapping[str, object]
+    root: ET.Element,
+    ns: MutableMapping[str, object],
+    *,
+    transactions: Optional[Sequence[ET.Element]] = None,
 ) -> Tuple[Optional[date], Optional[date]]:
     """Finn første og siste transaksjonsdato i SAF-T-filen."""
 
@@ -223,10 +249,11 @@ def _detect_transaction_span(
         for key, value in ns.items()
         if isinstance(key, str) and isinstance(value, str)
     }
-    transactions = root.findall(
-        ".//n1:GeneralLedgerEntries/n1:Journal/n1:Transaction",
-        ns_et or None,
-    )
+    if transactions is None:
+        transactions = root.findall(
+            ".//n1:GeneralLedgerEntries/n1:Journal/n1:Transaction",
+            ns_et or None,
+        )
     first_date: Optional[date] = None
     last_date: Optional[date] = None
     for transaction in transactions:

--- a/nordlys/saft/customer_analysis.py
+++ b/nordlys/saft/customer_analysis.py
@@ -89,9 +89,11 @@ def build_customer_supplier_analysis(
     observed_start, observed_end = _detect_transaction_span(
         root, ns, transactions=transactions
     )
-    analysis_year, parent_map = determine_analysis_year(
+    analysis_year, detected_parent_map = determine_analysis_year(
         header, root, ns, transaction_span=(observed_start, observed_end)
     )
+    if parent_map is None:
+        parent_map = detected_parent_map
     customer_sales: Optional["pd.DataFrame"] = None
     supplier_purchases: Optional["pd.DataFrame"] = None
     cost_vouchers: List["saft_customers.CostVoucher"] = []

--- a/nordlys/saft/customer_analysis.py
+++ b/nordlys/saft/customer_analysis.py
@@ -41,15 +41,15 @@ def determine_analysis_year(
     root: ET.Element,
     ns: MutableMapping[str, object],
     transaction_span: Optional[Tuple[Optional[date], Optional[date]]] = None,
+    parent_map: Optional[Dict[ET.Element, Optional[ET.Element]]] = None,
 ) -> Tuple[Optional[int], Optional[Dict[ET.Element, Optional[ET.Element]]]]:
     """Finn analyseår og parent-map basert på SAF-T-data."""
 
     period_start = _parse_date(header.period_start) if header else None
     period_end = _parse_date(header.period_end) if header else None
-    parent_map: Optional[Dict[ET.Element, Optional[ET.Element]]] = None
-
     if period_start or period_end:
-        parent_map = saft_customers.build_parent_map(root)
+        if parent_map is None:
+            parent_map = saft_customers.build_parent_map(root)
         if period_end:
             return period_end.year, parent_map
         if period_start:
@@ -90,7 +90,11 @@ def build_customer_supplier_analysis(
         root, ns, transactions=transactions
     )
     analysis_year, detected_parent_map = determine_analysis_year(
-        header, root, ns, transaction_span=(observed_start, observed_end)
+        header,
+        root,
+        ns,
+        transaction_span=(observed_start, observed_end),
+        parent_map=parent_map,
     )
     if parent_map is None:
         parent_map = detected_parent_map

--- a/nordlys/saft/extraction.py
+++ b/nordlys/saft/extraction.py
@@ -1,0 +1,57 @@
+"""Samlet ekstraksjon av grunnstrukturer fra SAF-T XML."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+import xml.etree.ElementTree as ET
+
+from .masterfiles import CustomerInfo, SupplierInfo, parse_customers_from_elements
+from .masterfiles import parse_suppliers_from_elements
+from .name_lookup import build_parent_map
+from .xml_helpers import NamespaceMap, _find, _findall
+
+
+@dataclass(frozen=True)
+class SaftExtractionBundle:
+    """Mellomresultater som kan deles mellom analysefunksjoner."""
+
+    account_elements: List[ET.Element]
+    customer_elements: List[ET.Element]
+    supplier_elements: List[ET.Element]
+    transactions: List[ET.Element]
+    parent_map: Dict[ET.Element, Optional[ET.Element]]
+    customers: Dict[str, CustomerInfo]
+    suppliers: Dict[str, SupplierInfo]
+
+
+def extract_saft_structures(root: ET.Element, ns: NamespaceMap) -> SaftExtractionBundle:
+    """Ekstraherer konti, kunder, leverandører og transaksjoner i ett pass."""
+
+    master_files = _find(root, "n1:MasterFiles", ns)
+    account_elements: List[ET.Element] = []
+    customer_elements: List[ET.Element] = []
+    supplier_elements: List[ET.Element] = []
+
+    if master_files is not None:
+        accounts_root = _find(master_files, "n1:GeneralLedgerAccounts", ns)
+        if accounts_root is not None:
+            account_elements = list(_findall(accounts_root, "n1:Account", ns))
+        customer_elements = list(_findall(master_files, "n1:Customer", ns))
+        supplier_elements = list(_findall(master_files, "n1:Supplier", ns))
+
+    transactions: List[ET.Element] = []
+    entries = _find(root, "n1:GeneralLedgerEntries", ns)
+    if entries is not None:
+        for journal in _findall(entries, "n1:Journal", ns):
+            transactions.extend(_findall(journal, "n1:Transaction", ns))
+
+    return SaftExtractionBundle(
+        account_elements=account_elements,
+        customer_elements=customer_elements,
+        supplier_elements=supplier_elements,
+        transactions=transactions,
+        parent_map=build_parent_map(root),
+        customers=parse_customers_from_elements(customer_elements),
+        suppliers=parse_suppliers_from_elements(supplier_elements),
+    )

--- a/nordlys/saft/extraction.py
+++ b/nordlys/saft/extraction.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 import xml.etree.ElementTree as ET
@@ -19,10 +20,39 @@ class SaftExtractionBundle:
     account_elements: List[ET.Element]
     customer_elements: List[ET.Element]
     supplier_elements: List[ET.Element]
-    transactions: List[ET.Element]
+    transactions: Sequence[ET.Element]
     parent_map: Dict[ET.Element, Optional[ET.Element]]
     customers: Dict[str, CustomerInfo]
     suppliers: Dict[str, SupplierInfo]
+
+
+class _JournalTransactionSequence(Sequence[ET.Element]):
+    """Sekvensvisning over transaksjoner uten å materialisere alle elementer."""
+
+    def __init__(self, journals: Sequence[ET.Element], ns: NamespaceMap) -> None:
+        self._journals = tuple(journals)
+        self._ns = ns
+
+    def __iter__(self) -> Iterator[ET.Element]:
+        for journal in self._journals:
+            yield from _findall(journal, "n1:Transaction", self._ns)
+
+    def __len__(self) -> int:
+        return sum(len(_findall(journal, "n1:Transaction", self._ns)) for journal in self._journals)
+
+    def __getitem__(self, index: int) -> ET.Element:
+        if index < 0:
+            index += len(self)
+        if index < 0:
+            raise IndexError(index)
+        offset = 0
+        for journal in self._journals:
+            transactions = _findall(journal, "n1:Transaction", self._ns)
+            next_offset = offset + len(transactions)
+            if index < next_offset:
+                return transactions[index - offset]
+            offset = next_offset
+        raise IndexError(index)
 
 
 def extract_saft_structures(root: ET.Element, ns: NamespaceMap) -> SaftExtractionBundle:
@@ -40,17 +70,16 @@ def extract_saft_structures(root: ET.Element, ns: NamespaceMap) -> SaftExtractio
         customer_elements = list(_findall(master_files, "n1:Customer", ns))
         supplier_elements = list(_findall(master_files, "n1:Supplier", ns))
 
-    transactions: List[ET.Element] = []
+    journals: List[ET.Element] = []
     entries = _find(root, "n1:GeneralLedgerEntries", ns)
     if entries is not None:
-        for journal in _findall(entries, "n1:Journal", ns):
-            transactions.extend(_findall(journal, "n1:Transaction", ns))
+        journals = list(_findall(entries, "n1:Journal", ns))
 
     return SaftExtractionBundle(
         account_elements=account_elements,
         customer_elements=customer_elements,
         supplier_elements=supplier_elements,
-        transactions=transactions,
+        transactions=_JournalTransactionSequence(journals, ns),
         parent_map=build_parent_map(root),
         customers=parse_customers_from_elements(customer_elements),
         suppliers=parse_suppliers_from_elements(supplier_elements),

--- a/nordlys/saft/extraction.py
+++ b/nordlys/saft/extraction.py
@@ -38,7 +38,10 @@ class _JournalTransactionSequence(Sequence[ET.Element]):
             yield from _findall(journal, "n1:Transaction", self._ns)
 
     def __len__(self) -> int:
-        return sum(len(_findall(journal, "n1:Transaction", self._ns)) for journal in self._journals)
+        return sum(
+            len(_findall(journal, "n1:Transaction", self._ns))
+            for journal in self._journals
+        )
 
     def __getitem__(self, index: int) -> ET.Element:
         if index < 0:

--- a/nordlys/saft/extraction.py
+++ b/nordlys/saft/extraction.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, overload
 import xml.etree.ElementTree as ET
 
 from .masterfiles import CustomerInfo, SupplierInfo, parse_customers_from_elements
@@ -38,24 +38,38 @@ class _JournalTransactionSequence(Sequence[ET.Element]):
             yield from _findall(journal, "n1:Transaction", self._ns)
 
     def __len__(self) -> int:
-        return sum(
-            len(_findall(journal, "n1:Transaction", self._ns))
-            for journal in self._journals
-        )
+        total = 0
+        for journal in self._journals:
+            total += len(self._transactions_for_journal(journal))
+        return total
 
-    def __getitem__(self, index: int) -> ET.Element:
+    @overload
+    def __getitem__(self, index: int) -> ET.Element: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[ET.Element]: ...
+
+    def __getitem__(self, index: int | slice) -> ET.Element | Sequence[ET.Element]:
+        if isinstance(index, slice):
+            return list(self)[index]
+        return self._get_by_index(index)
+
+    def _get_by_index(self, index: int) -> ET.Element:
         if index < 0:
             index += len(self)
         if index < 0:
             raise IndexError(index)
         offset = 0
         for journal in self._journals:
-            transactions = _findall(journal, "n1:Transaction", self._ns)
+            transactions = self._transactions_for_journal(journal)
             next_offset = offset + len(transactions)
             if index < next_offset:
                 return transactions[index - offset]
             offset = next_offset
         raise IndexError(index)
+
+    def _transactions_for_journal(self, journal: ET.Element) -> List[ET.Element]:
+        return list(_findall(journal, "n1:Transaction", self._ns))
 
 
 def extract_saft_structures(root: ET.Element, ns: NamespaceMap) -> SaftExtractionBundle:

--- a/nordlys/saft/loader.py
+++ b/nordlys/saft/loader.py
@@ -21,6 +21,7 @@ from .customer_analysis import (
     CustomerSupplierAnalysis,
     build_customer_supplier_analysis,
 )
+from .extraction import SaftExtractionBundle, extract_saft_structures
 from .trial_balance import TrialBalanceResult
 from .xml_helpers import NamespaceMap, _findall
 
@@ -89,8 +90,6 @@ class _SaftFutures:
     validation: Future["saft.SaftValidationResult"]
     enrichment: Future[BrregEnrichment]
     dataframe: Future["pd.DataFrame"]
-    customers: Future[Dict[str, "saft.CustomerInfo"]]
-    suppliers: Future[Dict[str, "saft.SupplierInfo"]]
     analysis: Future[CustomerSupplierAnalysis]
     trial_balance: Optional[Future["TrialBalanceResult"]]
 
@@ -113,6 +112,7 @@ def _submit_background_tasks(
     file_name: str,
     use_streaming: bool,
     parsed: _ParsedSaftContent,
+    extracted: SaftExtractionBundle,
     report_progress: Callable[[int, str], None],
 ) -> _SaftFutures:
     """Starter de mest tunge oppgavene i bakgrunnen."""
@@ -130,22 +130,24 @@ def _submit_background_tasks(
         parsed.header.file_version if parsed.header else None,
     )
     enrichment_future = executor.submit(enrich_from_header, parsed.header)
-    dataframe_future = executor.submit(saft.parse_saldobalanse, parsed.root)
-    customers_future = executor.submit(saft.parse_customers, parsed.root)
-    suppliers_future = executor.submit(saft.parse_suppliers, parsed.root)
+    dataframe_future = executor.submit(
+        saft.parse_saldobalanse,
+        parsed.root,
+        account_elements=extracted.account_elements,
+    )
     analysis_future = executor.submit(
         build_customer_supplier_analysis,
         parsed.header,
         parsed.root,
         parsed.namespaces,
+        parent_map=extracted.parent_map,
+        transactions=extracted.transactions,
     )
 
     return _SaftFutures(
         validation=validation_future,
         enrichment=enrichment_future,
         dataframe=dataframe_future,
-        customers=customers_future,
-        suppliers=suppliers_future,
         analysis=analysis_future,
         trial_balance=trial_balance_future,
     )
@@ -244,6 +246,7 @@ def load_saft_file(
 
     with ThreadPoolExecutor(max_workers=background_workers) as executor:
         parsed = _parse_saft_content(file_path)
+        extracted = extract_saft_structures(parsed.root, parsed.namespaces)
         header = parsed.header
         futures = _submit_background_tasks(
             executor,
@@ -251,12 +254,13 @@ def load_saft_file(
             file_name=file_name,
             use_streaming=use_streaming,
             parsed=parsed,
+            extracted=extracted,
             report_progress=_report_progress,
         )
 
         dataframe = futures.dataframe.result()
-        customers = futures.customers.result()
-        suppliers = futures.suppliers.result()
+        customers = extracted.customers
+        suppliers = extracted.suppliers
         _report_progress(25, f"Tolker saldobalanse for {file_name}")
 
         analysis: CustomerSupplierAnalysis = futures.analysis.result()
@@ -278,6 +282,7 @@ def load_saft_file(
             date_to=analysis.analysis_end_date,
             year=analysis.analysis_year,
             trial_balance=dataframe,
+            transactions=extracted.transactions,
         )
         bank_analysis = saft_customers.analyze_bank_postings(
             parsed.root,
@@ -286,6 +291,7 @@ def load_saft_file(
             date_to=analysis.analysis_end_date,
             year=analysis.analysis_year,
             trial_balance=dataframe,
+            transactions=extracted.transactions,
         )
 
         _report_progress(75, f"Validerer og beriker data for {file_name}")

--- a/nordlys/saft/masterfiles.py
+++ b/nordlys/saft/masterfiles.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Iterable
 
 from ..constants import NS
 from ..helpers import text_or_none
@@ -13,7 +13,9 @@ __all__ = [
     "CustomerInfo",
     "SupplierInfo",
     "parse_customers",
+    "parse_customers_from_elements",
     "parse_suppliers",
+    "parse_suppliers_from_elements",
 ]
 
 
@@ -35,11 +37,13 @@ class SupplierInfo:
     name: str
 
 
-def parse_customers(root: ET.Element) -> Dict[str, CustomerInfo]:
-    """Returnerer oppslag over kunder med kundenummer og navn."""
+def parse_customers_from_elements(
+    customer_elements: Iterable[ET.Element],
+) -> Dict[str, CustomerInfo]:
+    """Returnerer oppslag over kunder basert på ferdig uthentede XML-elementer."""
 
     customers: Dict[str, CustomerInfo] = {}
-    for element in root.findall(".//n1:MasterFiles/n1:Customer", NS):
+    for element in customer_elements:
         cid = text_or_none(element.find("n1:CustomerID", NS))
         if not cid:
             continue
@@ -65,11 +69,20 @@ def parse_customers(root: ET.Element) -> Dict[str, CustomerInfo]:
     return customers
 
 
-def parse_suppliers(root: ET.Element) -> Dict[str, SupplierInfo]:
-    """Returnerer oppslag over leverandører med nummer og navn."""
+def parse_customers(root: ET.Element) -> Dict[str, CustomerInfo]:
+    """Returnerer oppslag over kunder med kundenummer og navn."""
+
+    customer_elements = root.findall(".//n1:MasterFiles/n1:Customer", NS)
+    return parse_customers_from_elements(customer_elements)
+
+
+def parse_suppliers_from_elements(
+    supplier_elements: Iterable[ET.Element],
+) -> Dict[str, SupplierInfo]:
+    """Returnerer oppslag over leverandører fra ferdig uthentede elementer."""
 
     suppliers: Dict[str, SupplierInfo] = {}
-    for element in root.findall(".//n1:MasterFiles/n1:Supplier", NS):
+    for element in supplier_elements:
         sid = text_or_none(element.find("n1:SupplierID", NS))
         if not sid:
             continue
@@ -94,3 +107,10 @@ def parse_suppliers(root: ET.Element) -> Dict[str, SupplierInfo]:
             name=name,
         )
     return suppliers
+
+
+def parse_suppliers(root: ET.Element) -> Dict[str, SupplierInfo]:
+    """Returnerer oppslag over leverandører med nummer og navn."""
+
+    supplier_elements = root.findall(".//n1:MasterFiles/n1:Supplier", NS)
+    return parse_suppliers_from_elements(supplier_elements)

--- a/nordlys/saft/reporting_accounts.py
+++ b/nordlys/saft/reporting_accounts.py
@@ -75,6 +75,7 @@ def extract_cost_vouchers(
     date_from: Optional[object] = None,
     date_to: Optional[object] = None,
     parent_map: Optional[Dict[ET.Element, Optional[ET.Element]]] = None,
+    transactions: Optional[Sequence[ET.Element]] = None,
 ) -> List[CostVoucher]:
     """Henter kostnadsbilag med leverandørtilknytning fra SAF-T."""
 
@@ -98,7 +99,7 @@ def extract_cost_vouchers(
                 return text
         return None
 
-    for transaction in _iter_transactions(root, ns):
+    for transaction in _iter_transactions(root, ns, transactions=transactions):
         date_element = _find(transaction, "n1:TransactionDate", ns)
         tx_date = _ensure_date(date_element.text if date_element is not None else None)
         if tx_date is None:
@@ -204,6 +205,7 @@ def extract_all_vouchers(
     date_from: Optional[object] = None,
     date_to: Optional[object] = None,
     parent_map: Optional[Dict[ET.Element, Optional[ET.Element]]] = None,
+    transactions: Optional[Sequence[ET.Element]] = None,
 ) -> List[CostVoucher]:
     """Henter alle bilag i valgt periode/år med linjer og mva-koder."""
 
@@ -228,7 +230,7 @@ def extract_all_vouchers(
                 return text
         return None
 
-    for transaction in _iter_transactions(root, ns):
+    for transaction in _iter_transactions(root, ns, transactions=transactions):
         date_element = _find(transaction, "n1:TransactionDate", ns)
         tx_date = _ensure_date(date_element.text if date_element is not None else None)
         if tx_date is None:

--- a/nordlys/saft/reporting_customers.py
+++ b/nordlys/saft/reporting_customers.py
@@ -536,6 +536,7 @@ def _compute_customer_sales_map(
     year: Optional[int],
     last_period: Optional[int],
     include_suppliers: bool = False,
+    transactions: Optional[Sequence[ET.Element]] = None,
 ) -> Tuple[Dict[str, Decimal], Dict[str, int], Dict[str, Decimal], Dict[str, int]]:
     """Returnerer netto salg per kunde og (valgfritt) kostnader per leverandør."""
 
@@ -548,7 +549,7 @@ def _compute_customer_sales_map(
     use_range = start_date is not None or end_date is not None
     description_customer_map = _build_description_customer_map(root, ns)
 
-    for transaction in _iter_transactions(root, ns):
+    for transaction in _iter_transactions(root, ns, transactions=transactions):
         lines_list = list(_findall(transaction, "n1:Line", ns))
         if not lines_list:
             continue
@@ -621,6 +622,7 @@ def compute_customer_supplier_totals(
     date_from: Optional[object] = None,
     date_to: Optional[object] = None,
     parent_map: Optional[Dict[ET.Element, Optional[ET.Element]]] = None,
+    transactions: Optional[Sequence[ET.Element]] = None,
 ) -> Tuple["pd.DataFrame", "pd.DataFrame"]:
     """Beregner kundesalg og leverandørkjøp i ett pass gjennom transaksjonene."""
 
@@ -648,6 +650,7 @@ def compute_customer_supplier_totals(
         year=year,
         last_period=last_period if not use_range else None,
         include_suppliers=True,
+        transactions=transactions,
     )
 
     lookup_map = parent_map
@@ -867,6 +870,7 @@ def extract_credit_notes(
     *,
     months: Sequence[int] = tuple(range(1, 13)),
     year: Optional[int] = None,
+    transactions: Optional[Sequence[ET.Element]] = None,
 ) -> "pd.DataFrame":
     """Henter kreditnotaer i angitte måneder for 3xxx-konti gjennom året."""
 
@@ -877,7 +881,7 @@ def extract_credit_notes(
 
     rows: List[Dict[str, object]] = []
 
-    for transaction in _iter_transactions(root, ns):
+    for transaction in _iter_transactions(root, ns, transactions=transactions):
         scope = _build_transaction_scope(transaction, ns)
         tx_date = scope.date
         if tx_date is None or tx_date.month not in month_filter:
@@ -949,6 +953,7 @@ def analyze_sales_receivable_correlation(
     date_from: Optional[date] = None,
     date_to: Optional[date] = None,
     year: Optional[int] = None,
+    transactions: Optional[Sequence[ET.Element]] = None,
 ) -> SalesReceivableCorrelation:
     """Summerer salg etter om bilaget har motpost på 1500."""
 
@@ -959,7 +964,7 @@ def analyze_sales_receivable_correlation(
 
     use_range = date_from is not None or date_to is not None
 
-    for transaction in _iter_transactions(root, ns):
+    for transaction in _iter_transactions(root, ns, transactions=transactions):
         scope = _build_transaction_scope(transaction, ns)
         if not _transaction_in_scope(
             scope,
@@ -1088,6 +1093,7 @@ def analyze_receivable_postings(
     date_to: Optional[date] = None,
     year: Optional[int] = None,
     trial_balance: Optional["pd.DataFrame"] = None,
+    transactions: Optional[Sequence[ET.Element]] = None,
 ) -> ReceivablePostingAnalysis:
     """Summerer bevegelser på konto 1500 fordelt på motposter."""
 
@@ -1105,7 +1111,7 @@ def analyze_receivable_postings(
     other_total = Decimal("0")
     other_rows: List[Dict[str, object]] = []
 
-    for transaction in _iter_transactions(root, ns):
+    for transaction in _iter_transactions(root, ns, transactions=transactions):
         scope = _build_transaction_scope(transaction, ns)
         if not _transaction_in_scope(
             scope,
@@ -1247,6 +1253,7 @@ def analyze_bank_postings(
     date_to: Optional[date] = None,
     year: Optional[int] = None,
     trial_balance: Optional["pd.DataFrame"] = None,
+    transactions: Optional[Sequence[ET.Element]] = None,
 ) -> BankPostingAnalysis:
     """Summerer bankbevegelser fordelt på motpost kundefordringer."""
 
@@ -1262,7 +1269,7 @@ def analyze_bank_postings(
     without_receivable = Decimal("0")
     mismatched_rows: List[Dict[str, object]] = []
 
-    for transaction in _iter_transactions(root, ns):
+    for transaction in _iter_transactions(root, ns, transactions=transactions):
         scope = _build_transaction_scope(transaction, ns)
         if not _transaction_in_scope(
             scope,

--- a/nordlys/saft/reporting_utils.py
+++ b/nordlys/saft/reporting_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import xml.etree.ElementTree as ET
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Iterable, Optional, TYPE_CHECKING
+from typing import Iterable, Optional, Sequence, TYPE_CHECKING
 
 from ..helpers.lazy_imports import lazy_pandas
 from .xml_helpers import _find, _findall, NamespaceMap
@@ -59,7 +59,17 @@ def _ensure_date(value: Optional[object]) -> Optional[date]:
             return None
 
 
-def _iter_transactions(root: ET.Element, ns: NamespaceMap) -> Iterable[ET.Element]:
+def _iter_transactions(
+    root: ET.Element,
+    ns: NamespaceMap,
+    *,
+    transactions: Optional[Sequence[ET.Element]] = None,
+) -> Iterable[ET.Element]:
+    if transactions is not None:
+        for transaction in transactions:
+            yield transaction
+        return
+
     entries = _find(root, "n1:GeneralLedgerEntries", ns)
     if entries is None:
         return

--- a/nordlys/saft/trial_balance_summary.py
+++ b/nordlys/saft/trial_balance_summary.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import xml.etree.ElementTree as ET
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, cast
 
 from ..constants import NS
 from ..helpers import lazy_pandas, text_or_none, to_float
@@ -29,14 +29,19 @@ def _lazy_numpy() -> Any:
     return _NUMPY
 
 
-def parse_saldobalanse(root: ET.Element) -> "pd.DataFrame":
+def parse_saldobalanse(
+    root: ET.Element, *, account_elements: Optional[Sequence[ET.Element]] = None
+) -> "pd.DataFrame":
     """Returnerer saldobalansen som Pandas DataFrame."""
 
     if pd is None:
         raise RuntimeError("Pandas er ikke tilgjengelig for saldobalanse-parsing.")
 
-    gl = root.find("n1:MasterFiles/n1:GeneralLedgerAccounts", NS)
-    accounts = gl.iterfind("n1:Account", NS) if gl is not None else ()
+    if account_elements is None:
+        gl = root.find("n1:MasterFiles/n1:GeneralLedgerAccounts", NS)
+        accounts = gl.iterfind("n1:Account", NS) if gl is not None else ()
+    else:
+        accounts = account_elements
 
     def get(acct: ET.Element, tag: str) -> Optional[str]:
         return text_or_none(acct.find(f"n1:{tag}", NS))

--- a/nordlys/saft/trial_balance_summary.py
+++ b/nordlys/saft/trial_balance_summary.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import xml.etree.ElementTree as ET
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, cast
 
 from ..constants import NS
 from ..helpers import lazy_pandas, text_or_none, to_float
@@ -39,7 +39,9 @@ def parse_saldobalanse(
 
     if account_elements is None:
         gl = root.find("n1:MasterFiles/n1:GeneralLedgerAccounts", NS)
-        accounts = gl.iterfind("n1:Account", NS) if gl is not None else ()
+        accounts: Iterable[ET.Element] = (
+            gl.iterfind("n1:Account", NS) if gl is not None else ()
+        )
     else:
         accounts = account_elements
 

--- a/tests/test_saft.py
+++ b/tests/test_saft.py
@@ -28,6 +28,7 @@ from nordlys.saft.header import SaftHeader
 from nordlys.saft.customer_analysis import (
     _parse_date,
     build_customer_supplier_analysis,
+    determine_analysis_year,
 )
 from nordlys.saft.periods import format_header_period
 from nordlys.saft_customers import (
@@ -1944,6 +1945,44 @@ def test_build_customer_supplier_analysis_beholder_innsendt_parent_map(monkeypat
     build_customer_supplier_analysis(
         header, root, ns, parent_map=provided_parent_map, transactions=[]
     )
+
+
+def test_determine_analysis_year_beholder_innsendt_parent_map(monkeypatch):
+    xml = """
+    <AuditFile xmlns="urn:StandardAuditFile-Taxation-Financial:NO">
+      <Header>
+        <SelectionCriteria>
+          <PeriodStart>2023-01-01</PeriodStart>
+          <PeriodEnd>2023-12-31</PeriodEnd>
+        </SelectionCriteria>
+      </Header>
+    </AuditFile>
+    """
+    root = ET.fromstring(xml)
+    ns = {"n1": root.tag.split("}")[0][1:]}
+    header = parse_saft_header(root)
+    provided_parent_map = {root: None}
+
+    import nordlys.saft.customer_analysis as customer_analysis
+
+    def _build_parent_map_should_not_be_called(*_args, **_kwargs):
+        raise AssertionError("build_parent_map skal ikke kalles")
+
+    monkeypatch.setattr(
+        customer_analysis.saft_customers,
+        "build_parent_map",
+        _build_parent_map_should_not_be_called,
+    )
+
+    analysis_year, returned_parent_map = determine_analysis_year(
+        header,
+        root,
+        ns,
+        parent_map=provided_parent_map,
+    )
+
+    assert analysis_year == 2023
+    assert returned_parent_map is provided_parent_map
 
 
 def test_compute_purchases_includes_all_cost_accounts():

--- a/tests/test_saft.py
+++ b/tests/test_saft.py
@@ -1874,6 +1874,78 @@ def test_build_customer_supplier_analysis_handles_missing_transaction_dates():
     assert totals["PERIOD-ONLY"] == pytest.approx(500.0)
 
 
+def test_build_customer_supplier_analysis_beholder_innsendt_parent_map(monkeypatch):
+    xml = """
+    <AuditFile xmlns="urn:StandardAuditFile-Taxation-Financial:NO">
+      <Header>
+        <SelectionCriteria>
+          <PeriodStart>2023-01-01</PeriodStart>
+          <PeriodEnd>2023-12-31</PeriodEnd>
+        </SelectionCriteria>
+      </Header>
+      <GeneralLedgerEntries>
+        <Journal>
+          <Transaction>
+            <TransactionDate>2023-02-15</TransactionDate>
+            <Line>
+              <AccountID>3000</AccountID>
+              <CreditAmount>100</CreditAmount>
+            </Line>
+            <Line>
+              <AccountID>1500</AccountID>
+              <DebitAmount>100</DebitAmount>
+              <CustomerID>CUST-1</CustomerID>
+            </Line>
+          </Transaction>
+        </Journal>
+      </GeneralLedgerEntries>
+    </AuditFile>
+    """
+    root = ET.fromstring(xml)
+    ns = {"n1": root.tag.split("}")[0][1:]}
+    header = parse_saft_header(root)
+    provided_parent_map = {root: None}
+    detected_parent_map = {}
+
+    import nordlys.saft.customer_analysis as customer_analysis
+
+    monkeypatch.setattr(
+        customer_analysis,
+        "determine_analysis_year",
+        lambda *_args, **_kwargs: (2023, detected_parent_map),
+    )
+
+    def _assert_parent_map(*_args, **kwargs):
+        assert kwargs["parent_map"] is provided_parent_map
+        return pd.DataFrame(), pd.DataFrame()
+
+    monkeypatch.setattr(
+        customer_analysis.saft_customers,
+        "compute_customer_supplier_totals",
+        _assert_parent_map,
+    )
+    monkeypatch.setattr(
+        customer_analysis.saft_customers, "extract_cost_vouchers", lambda *_a, **_k: []
+    )
+    monkeypatch.setattr(
+        customer_analysis.saft_customers, "extract_all_vouchers", lambda *_a, **_k: []
+    )
+    monkeypatch.setattr(
+        customer_analysis.saft_customers,
+        "extract_credit_notes",
+        lambda *_a, **_k: pd.DataFrame(),
+    )
+    monkeypatch.setattr(
+        customer_analysis.saft_customers,
+        "analyze_sales_receivable_correlation",
+        lambda *_a, **_k: None,
+    )
+
+    build_customer_supplier_analysis(
+        header, root, ns, parent_map=provided_parent_map, transactions=[]
+    )
+
+
 def test_compute_purchases_includes_all_cost_accounts():
     xml = """
     <AuditFile xmlns="urn:StandardAuditFile-Taxation-Financial:NO">

--- a/tests/test_saft_extraction_pipeline.py
+++ b/tests/test_saft_extraction_pipeline.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import time
+import xml.etree.ElementTree as ET
+
+from nordlys.constants import NS
+from nordlys.saft import parse_saft_header, parse_saldobalanse
+from nordlys.saft.customer_analysis import build_customer_supplier_analysis
+from nordlys.saft.extraction import extract_saft_structures
+from nordlys.saft.reporting_customers import (
+    analyze_bank_postings,
+    analyze_receivable_postings,
+)
+
+
+def _build_saft_xml(transaction_count: int) -> str:
+    transactions: list[str] = []
+    for index in range(1, transaction_count + 1):
+        day = (index % 28) + 1
+        amount = 100 + (index % 11) * 10
+        vat = int(amount * 0.25)
+        gross = amount + vat
+        transactions.append(
+            f"""
+            <Transaction>
+              <TransactionID>T{index}</TransactionID>
+              <TransactionDate>2023-03-{day:02d}</TransactionDate>
+              <Line>
+                <AccountID>3000</AccountID>
+                <CreditAmount>{amount}</CreditAmount>
+              </Line>
+              <Line>
+                <AccountID>2700</AccountID>
+                <CreditAmount>{vat}</CreditAmount>
+              </Line>
+              <Line>
+                <AccountID>1500</AccountID>
+                <DebitAmount>{gross}</DebitAmount>
+                <CustomerID>K1</CustomerID>
+              </Line>
+            </Transaction>
+            """
+        )
+
+    joined_transactions = "".join(transactions)
+    return f"""
+    <AuditFile xmlns="urn:StandardAuditFile-Taxation-Financial:NO">
+      <Header>
+        <Company>
+          <Name>Test AS</Name>
+          <RegistrationNumber>999999999</RegistrationNumber>
+        </Company>
+        <SelectionCriteria>
+          <PeriodStart>2023-01-01</PeriodStart>
+          <PeriodEnd>2023-12-31</PeriodEnd>
+          <PeriodEndYear>2023</PeriodEndYear>
+        </SelectionCriteria>
+      </Header>
+      <MasterFiles>
+        <GeneralLedgerAccounts>
+          <Account>
+            <AccountID>1500</AccountID>
+            <AccountDescription>Kundefordringer</AccountDescription>
+            <OpeningDebitBalance>0</OpeningDebitBalance>
+            <OpeningCreditBalance>0</OpeningCreditBalance>
+            <ClosingDebitBalance>0</ClosingDebitBalance>
+            <ClosingCreditBalance>0</ClosingCreditBalance>
+          </Account>
+          <Account>
+            <AccountID>1900</AccountID>
+            <AccountDescription>Bank</AccountDescription>
+            <OpeningDebitBalance>0</OpeningDebitBalance>
+            <OpeningCreditBalance>0</OpeningCreditBalance>
+            <ClosingDebitBalance>0</ClosingDebitBalance>
+            <ClosingCreditBalance>0</ClosingCreditBalance>
+          </Account>
+          <Account>
+            <AccountID>3000</AccountID>
+            <AccountDescription>Salg</AccountDescription>
+            <OpeningDebitBalance>0</OpeningDebitBalance>
+            <OpeningCreditBalance>0</OpeningCreditBalance>
+            <ClosingDebitBalance>0</ClosingDebitBalance>
+            <ClosingCreditBalance>0</ClosingCreditBalance>
+          </Account>
+        </GeneralLedgerAccounts>
+        <Customer>
+          <CustomerID>K1</CustomerID>
+          <CustomerNumber>1001</CustomerNumber>
+          <Name>Kunde 1</Name>
+        </Customer>
+      </MasterFiles>
+      <GeneralLedgerEntries>
+        <Journal>
+          {joined_transactions}
+        </Journal>
+      </GeneralLedgerEntries>
+    </AuditFile>
+    """
+
+
+def _run_without_extraction(root: ET.Element) -> float:
+    start = time.perf_counter()
+    ns_map = dict(NS)
+    header = parse_saft_header(root)
+    trial_balance = parse_saldobalanse(root)
+    analysis = build_customer_supplier_analysis(header, root, ns_map)
+    analyze_receivable_postings(
+        root,
+        ns_map,
+        date_from=analysis.analysis_start_date,
+        date_to=analysis.analysis_end_date,
+        year=analysis.analysis_year,
+        trial_balance=trial_balance,
+    )
+    analyze_bank_postings(
+        root,
+        ns_map,
+        date_from=analysis.analysis_start_date,
+        date_to=analysis.analysis_end_date,
+        year=analysis.analysis_year,
+        trial_balance=trial_balance,
+    )
+    return time.perf_counter() - start
+
+
+def _run_with_extraction(root: ET.Element) -> tuple[float, int]:
+    start = time.perf_counter()
+    ns_map = dict(NS)
+    header = parse_saft_header(root)
+    extracted = extract_saft_structures(root, ns_map)
+    trial_balance = parse_saldobalanse(root, account_elements=extracted.account_elements)
+    analysis = build_customer_supplier_analysis(
+        header,
+        root,
+        ns_map,
+        parent_map=extracted.parent_map,
+        transactions=extracted.transactions,
+    )
+    analyze_receivable_postings(
+        root,
+        ns_map,
+        date_from=analysis.analysis_start_date,
+        date_to=analysis.analysis_end_date,
+        year=analysis.analysis_year,
+        trial_balance=trial_balance,
+        transactions=extracted.transactions,
+    )
+    analyze_bank_postings(
+        root,
+        ns_map,
+        date_from=analysis.analysis_start_date,
+        date_to=analysis.analysis_end_date,
+        year=analysis.analysis_year,
+        trial_balance=trial_balance,
+        transactions=extracted.transactions,
+    )
+    elapsed = time.perf_counter() - start
+    return elapsed, len(extracted.transactions)
+
+
+def test_extraction_pipeline_gjenbruker_data_og_har_forventet_ytelse():
+    small_root = ET.fromstring(_build_saft_xml(transaction_count=15))
+    medium_root = ET.fromstring(_build_saft_xml(transaction_count=250))
+
+    _ = _run_without_extraction(small_root)
+    _ = _run_with_extraction(ET.fromstring(_build_saft_xml(transaction_count=15)))
+
+    baseline_medium = _run_without_extraction(medium_root)
+    extracted_medium, tx_count = _run_with_extraction(
+        ET.fromstring(_build_saft_xml(transaction_count=250))
+    )
+
+    assert tx_count == 250
+    assert extracted_medium <= baseline_medium * 1.6

--- a/tests/test_saft_extraction_pipeline.py
+++ b/tests/test_saft_extraction_pipeline.py
@@ -171,6 +171,10 @@ def test_extraction_pipeline_gjenbruker_data_og_har_forventet_ytelse():
     extracted_medium, tx_count = _run_with_extraction(
         ET.fromstring(_build_saft_xml(transaction_count=250))
     )
+    extracted = extract_saft_structures(
+        ET.fromstring(_build_saft_xml(transaction_count=5)), dict(NS)
+    )
 
     assert tx_count == 250
+    assert not isinstance(extracted.transactions, list)
     assert extracted_medium <= baseline_medium * 1.6

--- a/tests/test_saft_extraction_pipeline.py
+++ b/tests/test_saft_extraction_pipeline.py
@@ -128,7 +128,9 @@ def _run_with_extraction(root: ET.Element) -> tuple[float, int]:
     ns_map = dict(NS)
     header = parse_saft_header(root)
     extracted = extract_saft_structures(root, ns_map)
-    trial_balance = parse_saldobalanse(root, account_elements=extracted.account_elements)
+    trial_balance = parse_saldobalanse(
+        root, account_elements=extracted.account_elements
+    )
     analysis = build_customer_supplier_analysis(
         header,
         root,

--- a/tests/test_saft_loader.py
+++ b/tests/test_saft_loader.py
@@ -107,7 +107,8 @@ def test_loader_triggers_validation_and_enrichment_early(tmp_path, monkeypatch):
             industry_error=None,
         )
 
-    def fake_parse_saldobalanse(root) -> pd.DataFrame:
+    def fake_parse_saldobalanse(root, *, account_elements=None) -> pd.DataFrame:
+        assert account_elements is not None
         assert validation_started.wait(timeout=1)
         assert enrichment_started.wait(timeout=1)
         return pd.DataFrame(
@@ -134,7 +135,7 @@ def test_loader_triggers_validation_and_enrichment_early(tmp_path, monkeypatch):
     monkeypatch.setattr(
         loader,
         "build_customer_supplier_analysis",
-        lambda header, root, ns: CustomerSupplierAnalysis(
+        lambda header, root, ns, **kwargs: CustomerSupplierAnalysis(
             analysis_year=None,
             customer_sales=None,
             supplier_purchases=None,
@@ -210,13 +211,17 @@ def test_loader_streams_trial_balance_for_heavy_files(tmp_path, monkeypatch):
             industry_error=None,
         ),
     )
-    monkeypatch.setattr(loader.saft, "parse_saldobalanse", lambda root: pd.DataFrame())
+    monkeypatch.setattr(
+        loader.saft,
+        "parse_saldobalanse",
+        lambda root, **kwargs: pd.DataFrame(),
+    )
     monkeypatch.setattr(loader.saft, "parse_customers", lambda root: {})
     monkeypatch.setattr(loader.saft, "parse_suppliers", lambda root: {})
     monkeypatch.setattr(
         loader,
         "build_customer_supplier_analysis",
-        lambda header, root, ns: CustomerSupplierAnalysis(
+        lambda header, root, ns, **kwargs: CustomerSupplierAnalysis(
             analysis_year=None,
             customer_sales=None,
             supplier_purchases=None,
@@ -359,7 +364,7 @@ def test_loader_runs_heavy_parsers_in_background_threads(tmp_path, monkeypatch):
             industry_error=None,
         )
 
-    def fake_parse_saldobalanse(root) -> pd.DataFrame:
+    def fake_parse_saldobalanse(root, **kwargs) -> pd.DataFrame:
         _record_thread()
         return pd.DataFrame(
             {
@@ -385,7 +390,7 @@ def test_loader_runs_heavy_parsers_in_background_threads(tmp_path, monkeypatch):
         _record_thread()
         return {}
 
-    def fake_build_analysis(header, root, ns):
+    def fake_build_analysis(header, root, ns, **kwargs):
         _record_thread()
         return CustomerSupplierAnalysis(
             analysis_year=None,


### PR DESCRIPTION
### Motivation
- Redusere unødvendige gjentatte XML-traverseringer ved import og analyse av SAF-T ved å ekstrahere grunnstrukturer én gang per fil.
- Holde eksisterende GUI-kontrakt intakt ved å bevare `SaftLoadResult`-API-et.

### Description
- Legg til ny modul `nordlys/saft/extraction.py` med `SaftExtractionBundle` og funksjonen `extract_saft_structures()` som henter ut konti, kunder, leverandører, transaksjoner og `parent_map` i ett pass.
- Oppdater `nordlys/saft/loader.py` til å kalle `extract_saft_structures()` og gjenbruke `account_elements`, `transactions`, `parent_map`, `customers` og `suppliers` i etterfølgende parsing- og analyseoppgaver; `SaftLoadResult` returneres uendret.
- Gjør parsing/analyse gjenbrukbar ved å legge til: `parse_customers_from_elements`/`parse_suppliers_from_elements` i `masterfiles.py`, utvidet `parse_saldobalanse(..., account_elements=...)` i `trial_balance_summary.py`, og støtte for valgfrie `transactions`-parametre i `_iter_transactions` og flere rapporteringsfunksjoner (`reporting_customers.py`, `reporting_accounts.py`, `reporting_utils.py`).
- Legg til ytelsesnær test `tests/test_saft_extraction_pipeline.py` (liten/medium fil) og tilpass eksisterende loader-tester for nye valgfrie argumenter slik at bakoverkompatibilitet beholdes.

### Testing
- Kjørte `python -m pytest tests/test_saft_extraction_pipeline.py tests/test_saft_loader.py tests/test_reporting_utils.py -q` og alle tester passerte (`17 passed`).
- Kjørte `python -m ruff check nordlys/saft/extraction.py nordlys/saft/masterfiles.py nordlys/saft/trial_balance_summary.py nordlys/saft/reporting_utils.py nordlys/saft/reporting_accounts.py nordlys/saft/reporting_customers.py nordlys/saft/customer_analysis.py nordlys/saft/loader.py tests/test_saft_extraction_pipeline.py tests/test_saft_loader.py` og fikk ingen Ruff-feil (`All checks passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb548e7fc832883d78f30ba386832)